### PR TITLE
MAM-3456-performance-dont-update-unreadindicator-on-scroll

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -480,6 +480,22 @@ extension NewsFeedViewController {
         } else if let cell = cell as? ActivityCardCell {
             cell.display()
         }
+        
+        if self.viewModel.getUnreadEnabled(forFeed: self.viewModel.type) {
+            let currentRow = indexPath.row
+            let unreadState = self.viewModel.getUnreadState(forFeed: self.viewModel.type)
+            let count = min(currentRow, unreadState.count)
+            self.viewModel.setUnreadState(count: count, enabled: true, forFeed: self.viewModel.type)
+            
+            switch self.viewModel.type {
+            case .mentionsIn, .mentionsOut, .activity:
+                self.unreadIndicator.isEnabled = true
+                self.unreadIndicator.configure(unreadCount: count)
+            default:
+                self.latestPill.isEnabled = true
+                self.latestPill.configure(unreadCount: count, picUrls: unreadState.unreadPics)
+            }
+        }
     }
     
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -581,22 +597,6 @@ extension NewsFeedViewController {
             Task { [weak self] in
                 guard let self else { return }
                 try await viewModel.loadListData(type: nil, fetchType: .nextPage)
-            }
-        }
-        
-        if self.viewModel.getUnreadEnabled(forFeed: self.viewModel.type) {
-            let currentRow = self.getCurrentCellIndexPath(tableView: self.tableView)?.row ?? 0
-            let unreadState = self.viewModel.getUnreadState(forFeed: self.viewModel.type)
-            let count = min(currentRow, unreadState.count)
-            self.viewModel.setUnreadState(count: count, enabled: true, forFeed: self.viewModel.type)
-            
-            switch self.viewModel.type {
-            case .mentionsIn, .mentionsOut, .activity:
-                self.unreadIndicator.isEnabled = true
-                self.unreadIndicator.configure(unreadCount: count)
-            default:
-                self.latestPill.isEnabled = true
-                self.latestPill.configure(unreadCount: count, picUrls: unreadState.unreadPics)
             }
         }
         


### PR DESCRIPTION
Instead of updating the unreadIndicator count and visibility (17ms) in `scrollViewDidScroll`, update it in `tableView:willDisplay:forRowAt` instead.

Calling `getCurrentCellIndexPath` (10ms) and `LatestPill.isEnabled.setter` (9ms) are expensive operations.

https://linear.app/theblvd/issue/MAM-3456/performance-dont-update-unreadindicator-on-scroll

<img width="1690" alt="Screenshot 2023-12-11 at 15 06 21" src="https://github.com/TheBLVD/mammoth/assets/221925/df9a410b-bf34-4f9d-b797-6ef8d8a63d95">
