### PR TITLE
MAM-3469-performance-only-parse-user-description-html-when-loading

### DIFF
--- a/Mammoth/Models/UserCardModel.swift
+++ b/Mammoth/Models/UserCardModel.swift
@@ -67,7 +67,7 @@ class UserCardModel {
         self.account = account
         
         self.richName = NSAttributedString(string: self.name)
-        self.richDescription = NSAttributedString()
+        self.richDescription = nil
         self.richPreviewDescription = self.description != nil ? removeTrailingLinebreaks(string: NSAttributedString(string: self.description!)) : nil
         
         self.instanceName = nil
@@ -85,11 +85,6 @@ class UserCardModel {
         
         self.fields = account?.fields
         self.joinedOn = account?.createdAt?.toDate()
-        
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.richDescription = self.description != nil ? parseRichText(text: description) : nil
-        }
     }
     
     init(account: Account, instanceName: String? = nil, requestFollowStatusUpdate: FollowManager.NetworkUpdateType = .none) {
@@ -105,7 +100,7 @@ class UserCardModel {
         self.account = account
         
         self.richName = NSAttributedString(string: self.name)
-        self.richDescription = NSAttributedString()
+        self.richDescription = nil
         self.richPreviewDescription = self.description != nil ? removeTrailingLinebreaks(string: NSAttributedString(string: self.description!)) : nil
         
         self.instanceName = instanceName
@@ -123,11 +118,6 @@ class UserCardModel {
         
         self.fields = account.fields
         self.joinedOn = account.createdAt?.toDate()
-        
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.richDescription = self.description != nil ? parseRichText(text: account.note) : nil
-        }
     }
     
     // Return an instance without description
@@ -153,6 +143,12 @@ class UserCardModel {
     
     static func isOwn(account: Account) -> Bool {
         return AccountsManager.shared.currentUser()?.fullAcct != nil && AccountsManager.shared.currentUser()?.fullAcct == account.fullAcct
+    }
+    
+    @discardableResult
+    public func loadHTMLDescription() -> NSAttributedString? {
+        self.richDescription = self.description != nil ? parseRichText(text: description) : nil
+        return self.richDescription
     }
     
 }

--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -97,6 +97,7 @@ final class ProfileViewModel {
             if let account = await AccountService.lookup(fullAcct, serverName: serverName) {
                 let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
                 await MainActor.run {
+                    user.loadHTMLDescription()
                     self.user = user
                 }
                 
@@ -113,6 +114,7 @@ final class ProfileViewModel {
     init(_ type: ViewTypes = .posts, user: UserCardModel?, screenType: ProfileScreenType = .own) {
         self.type = type
         self.user = user
+        self.user?.loadHTMLDescription()
         self.screenType = (user?.isSelf ?? false) ? .own : screenType
         self.state = .success
         

--- a/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
@@ -345,31 +345,39 @@ extension ProfileHeader {
                 descriptionLabel.addHorizontalFillConstraints(withParent: contentStackView, andMaxWidth: 420, constant: -(contentStackView.layoutMargins.left + contentStackView.layoutMargins.right))
             }
             
-            self.descriptionLabel.mentionColor = .custom.highContrast
-            self.descriptionLabel.hashtagColor = .custom.highContrast
-            self.descriptionLabel.URLColor = .custom.highContrast
-            self.descriptionLabel.emailColor = .custom.highContrast
-            self.descriptionLabel.textColor = .custom.highContrast
-            
-            // Post text link handlers
-            self.descriptionLabel.handleURLTap { url in
-                self.onButtonPress?(.link, .url(url))
-            }
-            self.descriptionLabel.handleHashtagTap { hashtag in
-                self.onButtonPress?(.link, .hashtag(hashtag))
-            }
-            self.descriptionLabel.handleMentionTap { mention in
-                if let (range, _, _) = self.descriptionLabel.selectedElement {
-                    if let url = self.user?.richDescription?.attribute(.link, at: range.location, effectiveRange: nil) as? URL {
-                        self.onButtonPress?(.link, .mention("@\(mention)@\(url.host ?? "")"))
-                        return
+            self.descriptionLabel.customize { [weak self] label in
+                guard let self else { return }
+                label.mentionColor = .custom.highContrast
+                label.hashtagColor = .custom.highContrast
+                label.URLColor = .custom.highContrast
+                label.emailColor = .custom.highContrast
+                label.textColor = .custom.highContrast
+                
+                // Post text link handlers
+                label.handleURLTap { [weak self] url in
+                    guard let self else { return }
+                    self.onButtonPress?(.link, .url(url))
+                }
+                label.handleHashtagTap { [weak self] hashtag in
+                    guard let self else { return }
+                    self.onButtonPress?(.link, .hashtag(hashtag))
+                }
+                label.handleMentionTap { [weak self] mention in
+                    guard let self else { return }
+                    if let (range, _, _) = self.descriptionLabel.selectedElement {
+                        if let url = self.user?.richDescription?.attribute(.link, at: range.location, effectiveRange: nil) as? URL {
+                            self.onButtonPress?(.link, .mention("@\(mention)@\(url.host ?? "")"))
+                            return
+                        }
                     }
+                    
+                    self.onButtonPress?(.link, .mention(mention))
+                }
+                label.handleEmailTap { [weak self] email in
+                    guard let self else { return }
+                    self.onButtonPress?(.link, .email(email))
                 }
                 
-                self.onButtonPress?(.link, .mention(mention))
-            }
-            self.descriptionLabel.handleEmailTap { email in
-                self.onButtonPress?(.link, .email(email))
             }
             
         } else {


### PR DESCRIPTION
...-profile

We only need to parse the description html on the profile screen (to make all links work correctly). In other places (UserCardCell) we use a stripped version of the description html and display that instead (faster)

https://linear.app/theblvd/issue/MAM-3469/performance-only-parse-user-description-html-when-loading-profile