### PR TITLE
MAM-3470-performance-time-should-not-be-computed-property

### DIFF
--- a/Mammoth/Models/ActivityCardModel.swift
+++ b/Mammoth/Models/ActivityCardModel.swift
@@ -16,10 +16,8 @@ struct ActivityCardModel {
     let notification: Notificationt
     var postCard: PostCardModel?
     let user: UserCardModel
-    
-    var time: String {
-        return Self.formattedTime(notification: notification, formatter: GlobalStruct.dateFormatter)
-    }
+    var createdAt: Date
+    var time: String
     
     // Debug properties
     var batchId: String?
@@ -31,6 +29,8 @@ struct ActivityCardModel {
         self.cursorId = self.id
         self.type = notification.type
         self.notification = notification
+        self.createdAt = notification.createdAt.toDate()
+        self.time = Self.formattedTime(notification: notification, formatter: GlobalStruct.dateFormatter)
         
         if let status = notification.status {
             self.postCard = PostCardModel(status: status)

--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -225,17 +225,9 @@ final class PostCardModel {
             return false
         }
     }
-    
-    var time: String {
-        switch data {
-        case .mastodon(let status):
-            return PostCardModel.formattedTime(status: status, formatter: GlobalStruct.dateFormatter)
-            
-        case .bluesky(let postVM):
-            return postVM.post.record.createdAt.toStringWithRelativeTime()
-        }
-    }
-    
+
+    var time: String
+        
     var source: String {
         var sourceDescription = ""
         if let statusSource, statusSource.count > 0 {
@@ -278,6 +270,8 @@ final class PostCardModel {
         self.url = status.reblog?.url ?? status.url
         self.uri = status.reblog?.uri ?? status.uri
         self.createdAt = (status.reblog?.createdAt ?? status.createdAt).toDate()
+        self.time = PostCardModel.formattedTime(status: status, formatter: GlobalStruct.dateFormatter)
+            
         self.emojis = status.reblog?.emojis ?? status.emojis
         
         // Username formatting
@@ -455,6 +449,8 @@ final class PostCardModel {
         self.url = nil
         self.uri = nil
         self.createdAt = Date()
+        self.time = postVM.post.record.createdAt.toStringWithRelativeTime()
+        
         self.emojis = nil
         
         // Username formatting

--- a/Mammoth/Screens/DetailScreen/DetailViewController.swift
+++ b/Mammoth/Screens/DetailScreen/DetailViewController.swift
@@ -182,13 +182,13 @@ class DetailViewController: UIViewController {
 extension DetailViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.display()
+            cell.willDisplay()
         }
     }
     
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.endDisplay()
+            cell.didEndDisplay()
         }
     }
     

--- a/Mammoth/Screens/DetailScreen/DetailViewController.swift
+++ b/Mammoth/Screens/DetailScreen/DetailViewController.swift
@@ -180,6 +180,18 @@ class DetailViewController: UIViewController {
 
 // MARK: UITableViewDataSource & UITableViewDelegate
 extension DetailViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if let cell = cell as? PostCardCell {
+            cell.display()
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if let cell = cell as? PostCardCell {
+            cell.endDisplay()
+        }
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfItems(forSection: section)
     }
@@ -232,6 +244,7 @@ extension DetailViewController: UITableViewDataSource, UITableViewDelegate {
                         }
                     }
                 }
+                
                 return cell
             }
             
@@ -263,6 +276,7 @@ extension DetailViewController: UITableViewDataSource, UITableViewDelegate {
                         self.viewModel.post.videoPlayer?.pause()
                     }
                 }
+                
                 return cell
             }
         default:

--- a/Mammoth/Screens/DiscoveryScreen/PostResultsViewController.swift
+++ b/Mammoth/Screens/DiscoveryScreen/PostResultsViewController.swift
@@ -164,13 +164,13 @@ private extension PostResultsViewController {
 extension PostResultsViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.display()
+            cell.willDisplay()
         }
     }
     
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.endDisplay()
+            cell.didEndDisplay()
         }
     }
     

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -476,9 +476,9 @@ extension NewsFeedViewController {
         }
         
         if let cell = cell as? PostCardCell {
-            cell.display()
+            cell.willDisplay()
         } else if let cell = cell as? ActivityCardCell {
-            cell.display()
+            cell.willDisplay()
         }
         
         if self.viewModel.getUnreadEnabled(forFeed: self.viewModel.type) {
@@ -502,9 +502,9 @@ extension NewsFeedViewController {
         self.viewModel.cancelItemSync(forIndexPath: indexPath)
         
         if let cell = cell as? PostCardCell {
-            cell.endDisplay()
+            cell.didEndDisplay()
         } else if let cell = cell as? ActivityCardCell {
-            cell.endDisplay()
+            cell.didEndDisplay()
         }
     }
     

--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -419,13 +419,13 @@ extension ProfileViewController: UITableViewDataSource, UITableViewDataSourcePre
     
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.display()
+            cell.willDisplay()
         }
     }
     
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let cell = cell as? PostCardCell {
-            cell.endDisplay()
+            cell.didEndDisplay()
         }
     }
     

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -168,7 +168,7 @@ final class ActivityCardCell: UITableViewCell {
     }
     
     /// the cell will be displayed in the tableview
-    public func display() {
+    public func willDisplay() {
         if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             if GlobalStruct.autoPlayVideos {
                 self.video?.play()
@@ -179,7 +179,7 @@ final class ActivityCardCell: UITableViewCell {
     }
     
     // the cell will end being displayed in the tableview
-    public func endDisplay() {
+    public func didEndDisplay() {
         if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             self.video?.pause()
         }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -174,6 +174,8 @@ final class ActivityCardCell: UITableViewCell {
                 self.video?.play()
             }
         }
+        
+        self.header.startTimeUpdates()
     }
     
     // the cell will end being displayed in the tableview
@@ -181,6 +183,8 @@ final class ActivityCardCell: UITableViewCell {
         if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             self.video?.pause()
         }
+        
+        self.header.stopTimeUpdates()
     }
 }
 

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -73,7 +73,6 @@ class ActivityCardHeader: UIView {
     private var activity: ActivityCardModel?
     public var onPress: PostCardButtonCallback?
     
-    private let runLoop = RunLoop.main
     private var subscription: Cancellable?
     
     override init(frame: CGRect) {
@@ -212,7 +211,7 @@ extension ActivityCardHeader {
                 delay = 60*15
             }
             
-            self.subscription = self.runLoop.schedule(
+            self.subscription = RunLoop.main.schedule(
                 after: .init(Date(timeIntervalSinceNow: delay)),
                 interval: .seconds(interval),
                 tolerance: .seconds(1)

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 class ActivityCardHeader: UIView {
     
@@ -72,13 +73,22 @@ class ActivityCardHeader: UIView {
     private var activity: ActivityCardModel?
     public var onPress: PostCardButtonCallback?
     
+    private let runLoop = RunLoop.main
+    private var subscription: Cancellable?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setupUI()
+        NotificationCenter.default.addObserver(self, selector: #selector(self.stopTimeUpdates), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        self.stopTimeUpdates()
+        NotificationCenter.default.removeObserver(self)
     }
     
     func prepareForReuse() {
@@ -93,6 +103,7 @@ class ActivityCardHeader: UIView {
             self.pinIcon.removeFromSuperview()
         }
         setupUIFromSettings()
+        self.stopTimeUpdates()
     }
 }
 
@@ -179,6 +190,46 @@ extension ActivityCardHeader {
     }
     
     func onThemeChange() {}
+    
+    func startTimeUpdates() {
+        if let createdAt = self.activity?.postCard?.createdAt {
+            var interval: Double = 60*60
+            var delay: Double = 60*15
+            let now = Date()
+            
+            let secondsRange = now.addingTimeInterval(-60)...now
+            let minutesRange = now.addingTimeInterval(-60*60)...now
+            let hoursRange = now.addingTimeInterval(-60*60*24)...now
+            
+            if secondsRange ~= createdAt {
+                interval = 5
+                delay = 8
+            } else if minutesRange ~= createdAt {
+                interval = 30
+                delay = 15
+            } else if hoursRange ~= createdAt {
+                interval = 60*60
+                delay = 60*15
+            }
+            
+            self.subscription = self.runLoop.schedule(
+                after: .init(Date(timeIntervalSinceNow: delay)),
+                interval: .seconds(interval),
+                tolerance: .seconds(1)
+            ) { [weak self] in
+                guard let self else { return }
+                if let notification = self.activity?.notification {
+                    let newTime = ActivityCardModel.formattedTime(notification: notification, formatter: GlobalStruct.dateFormatter)
+                    self.activity?.time = newTime
+                    self.dateLabel.text = newTime
+                }
+            }
+        }
+    }
+    
+    @objc func stopTimeUpdates() {
+        self.subscription?.cancel()
+    }
 }
 
 // MARK: - Handlers

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -695,7 +695,7 @@ extension PostCardCell {
     }
     
     /// the cell will be displayed in the tableview
-    public func display() {
+    public func willDisplay() {
         if let postCard = self.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             if GlobalStruct.autoPlayVideos {
                 self.video?.play()
@@ -710,7 +710,7 @@ extension PostCardCell {
     }
     
     // the cell will end being displayed in the tableview
-    public func endDisplay() {
+    public func didEndDisplay() {
         if let postCard = self.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             self.video?.pause()
         }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -705,6 +705,8 @@ extension PostCardCell {
         if let postCard = self.postCard, postCard.hasQuotePost {
             postCard.preloadQuotePost()
         }
+        
+        self.header.startTimeUpdates()
     }
     
     // the cell will end being displayed in the tableview
@@ -712,6 +714,8 @@ extension PostCardCell {
         if let postCard = self.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
             self.video?.pause()
         }
+        
+        self.header.stopTimeUpdates()
     }
     
     @objc private func onTextLongPress(recognizer: UIGestureRecognizer) {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -128,7 +128,6 @@ class PostCardHeader: UIView {
     private var type: PostCardHeaderTypes = .regular
     public var onPress: PostCardButtonCallback?
     
-    private let runLoop = RunLoop.main
     private var subscription: Cancellable?
 
     override init(frame: CGRect) {
@@ -347,7 +346,7 @@ extension PostCardHeader {
                 delay = 60*15
             }
             
-            self.subscription = self.runLoop.schedule(
+            self.subscription = RunLoop.main.schedule(
                 after: .init(Date(timeIntervalSinceNow: delay)),
                 interval: .seconds(interval),
                 tolerance: .seconds(1)


### PR DESCRIPTION
In PostCardModel and ActivityCardModel we do not want time to be a computed property. Calling NSDateFormatter methods just-in-time seems to be expensive. Instead we set time once during init and update the value when the label is displayed using a custom time interval.

https://linear.app/theblvd/issue/MAM-3470/performance-time-should-not-be-computed-property