### PR TITLE
MAM-3480-performance-update-activelabel-less-often

### DIFF
--- a/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
@@ -333,20 +333,21 @@ extension ProfileHeader {
         
         self.userTagLabel.attributedText = self.formatUserTag(user: user)
         
-        if let description = user.richDescription {
-            self.descriptionLabel.attributedText = formatRichText(string: description, label: self.descriptionLabel, emojis: user.emojis)
-        } else {
-            self.descriptionLabel.text = user.description
-        }
-
-        if let description = user.description, !description.isEmpty {
-            if !contentStackView.arrangedSubviews.contains(descriptionLabel) {
-                contentStackView.insertArrangedSubview(descriptionLabel, at: 0)
-                descriptionLabel.addHorizontalFillConstraints(withParent: contentStackView, andMaxWidth: 420, constant: -(contentStackView.layoutMargins.left + contentStackView.layoutMargins.right))
+        self.descriptionLabel.customize { [weak self] label in
+            guard let self else { return }
+            
+            if let description = user.richDescription {
+                label.attributedText = formatRichText(string: description, label: label, emojis: user.emojis)
+            } else {
+                label.text = user.description
             }
             
-            self.descriptionLabel.customize { [weak self] label in
-                guard let self else { return }
+            if let description = user.description, !description.isEmpty {
+                if !contentStackView.arrangedSubviews.contains(descriptionLabel) {
+                    contentStackView.insertArrangedSubview(descriptionLabel, at: 0)
+                    descriptionLabel.addHorizontalFillConstraints(withParent: contentStackView, andMaxWidth: 420, constant: -(contentStackView.layoutMargins.left + contentStackView.layoutMargins.right))
+                }
+                
                 label.mentionColor = .custom.highContrast
                 label.hashtagColor = .custom.highContrast
                 label.URLColor = .custom.highContrast
@@ -354,16 +355,13 @@ extension ProfileHeader {
                 label.textColor = .custom.highContrast
                 
                 // Post text link handlers
-                label.handleURLTap { [weak self] url in
-                    guard let self else { return }
+                label.handleURLTap { url in
                     self.onButtonPress?(.link, .url(url))
                 }
-                label.handleHashtagTap { [weak self] hashtag in
-                    guard let self else { return }
+                label.handleHashtagTap { hashtag in
                     self.onButtonPress?(.link, .hashtag(hashtag))
                 }
-                label.handleMentionTap { [weak self] mention in
-                    guard let self else { return }
+                label.handleMentionTap { mention in
                     if let (range, _, _) = self.descriptionLabel.selectedElement {
                         if let url = self.user?.richDescription?.attribute(.link, at: range.location, effectiveRange: nil) as? URL {
                             self.onButtonPress?(.link, .mention("@\(mention)@\(url.host ?? "")"))
@@ -373,18 +371,17 @@ extension ProfileHeader {
                     
                     self.onButtonPress?(.link, .mention(mention))
                 }
-                label.handleEmailTap { [weak self] email in
-                    guard let self else { return }
+                label.handleEmailTap { email in
                     self.onButtonPress?(.link, .email(email))
                 }
                 
-            }
-            
-        } else {
-            if contentStackView.arrangedSubviews.contains(descriptionLabel) {
-                contentStackView.removeArrangedSubview(descriptionLabel)
-                descriptionLabel.removeFromSuperview()
-                descriptionLabel.constraints.forEach({ $0.isActive = false })
+                
+            } else {
+                if contentStackView.arrangedSubviews.contains(descriptionLabel) {
+                    contentStackView.removeArrangedSubview(descriptionLabel)
+                    descriptionLabel.removeFromSuperview()
+                    descriptionLabel.constraints.forEach({ $0.isActive = false })
+                }
             }
         }
         

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -101,8 +101,13 @@ class ActivityCardHeader: UIView {
             self.rightAttributesStack.removeArrangedSubview(self.pinIcon)
             self.pinIcon.removeFromSuperview()
         }
-        setupUIFromSettings()
         self.stopTimeUpdates()
+    }
+    
+    func setupUIFromSettings() {
+        actionLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
+        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
+        dateLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 }
 
@@ -137,12 +142,6 @@ private extension ActivityCardHeader {
         headerTitleStackView.addArrangedSubview(actionLabel)
         
         setupUIFromSettings()
-    }
-    
-    func setupUIFromSettings() {
-        actionLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
-        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
-        dateLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 
 }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -101,7 +101,6 @@ class ActivityCardHeader: UIView {
             self.rightAttributesStack.removeArrangedSubview(self.pinIcon)
             self.pinIcon.removeFromSuperview()
         }
-        self.stopTimeUpdates()
     }
     
     func setupUIFromSettings() {

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -101,6 +101,8 @@ class ActivityCardHeader: UIView {
             self.rightAttributesStack.removeArrangedSubview(self.pinIcon)
             self.pinIcon.removeFromSuperview()
         }
+
+        self.stopTimeUpdates()
     }
     
     func setupUIFromSettings() {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -423,6 +423,8 @@ private extension PostCardCell {
         self.header.setupUIFromSettings()
         self.linkPreview?.setupUIFromSettings()
         self.quotePost?.setupUIFromSettings()
+        self.headerExtension?.setupUIFromSettings()
+        self.metadata?.setupUIFromSettings()
         
         self.onThemeChange()
     }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -242,6 +242,15 @@ final class PostCardCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.setupUIFromSettings),
+                                               name: NSNotification.Name(rawValue: "reloadAll"),
+                                               object: nil)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     required init?(coder: NSCoder) {
@@ -323,8 +332,6 @@ final class PostCardCell: UITableViewCell {
             headerExtension.removeFromSuperview()
             headerExtension.prepareForReuse()
         }
-        
-        setupUIFromSettings()
     }
 }
 
@@ -402,7 +409,7 @@ private extension PostCardCell {
         setupUIFromSettings()
     }
     
-    func setupUIFromSettings() {
+    @objc func setupUIFromSettings() {
         deletedWarningButton.titleLabel?.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
         postTextLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
         postTextLabel.minimumLineHeight = DeviceHelpers.isiOSAppOnMac() ? UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 5 : 0
@@ -412,6 +419,12 @@ private extension PostCardCell {
         } else {
             contentView.layoutMargins = .init(top: 16, left: 13, bottom: 0, right: 13)
         }
+        
+        self.header.setupUIFromSettings()
+        self.linkPreview?.setupUIFromSettings()
+        self.quotePost?.setupUIFromSettings()
+        
+        self.onThemeChange()
     }
 }
 
@@ -463,26 +476,29 @@ extension PostCardCell {
             }
         }
         
-        if case .mastodon(let status) = postCard.data,
-            let postText = postCard.richPostText {
+        self.postTextLabel.customize { [weak self] label in
+            guard let self else { return }
+            if case .mastodon(let status) = postCard.data,
+               let postText = postCard.richPostText {
+                
+                label.attributedText = formatRichText(string: postText, label: label, emojis: status.reblog?.emojis ?? status.emojis)
+            } else {
+                label.text = postCard.postText
+            }
+            label.numberOfLines = type.numberOfLines
             
-            self.postTextLabel.attributedText = formatRichText(string: postText, label: self.postTextLabel, emojis: status.reblog?.emojis ?? status.emojis)
-        } else {
-            self.postTextLabel.text = postCard.postText
-        }
-        self.postTextLabel.numberOfLines = type.numberOfLines
-        
-        // Post text link handlers
-        self.postTextLabel.handleURLTap { url in
-            onButtonPress(.link, true, .url(url))
-        }
-        self.postTextLabel.handleHashtagTap { hashtag in
-            onButtonPress(.link, true, .hashtag(hashtag))
-        }
-        
-        if case .mastodon(let status) = postCard.data {
-            self.postTextLabel.handleMentionTap { mention in
-                onButtonPress(.link, true, .mention((mention, status)))
+            // Post text link handlers
+            label.handleURLTap { url in
+                onButtonPress(.link, true, .url(url))
+            }
+            label.handleHashtagTap { hashtag in
+                onButtonPress(.link, true, .hashtag(hashtag))
+            }
+            
+            if case .mastodon(let status) = postCard.data {
+                label.handleMentionTap { mention in
+                    onButtonPress(.link, true, .mention((mention, status)))
+                }
             }
         }
         
@@ -684,9 +700,6 @@ extension PostCardCell {
         // Make sure all views are underneath the contentWarningButton and the deletedWarningButton
         self.contentStackView.bringSubviewToFront(self.contentWarningButton)
         self.contentStackView.bringSubviewToFront(self.deletedWarningButton)
-
-        // TODO: only call this when theme changes
-        self.onThemeChange()
         
         if CommandLine.arguments.contains("-M_DEBUG_TIMELINES") {
             // Configure for debugging
@@ -797,11 +810,14 @@ extension PostCardCell {
             self.contentView.backgroundColor = .custom.background
         }
         
-        self.postTextLabel.mentionColor = .custom.highContrast
-        self.postTextLabel.hashtagColor = .custom.highContrast
-        self.postTextLabel.URLColor = .custom.highContrast
-        self.postTextLabel.emailColor = .custom.highContrast
-        self.postTextLabel.backgroundColor = self.contentView.backgroundColor
+        self.postTextLabel.customize { [weak self] label in
+            guard let self else { return }
+            label.mentionColor = .custom.highContrast
+            label.hashtagColor = .custom.highContrast
+            label.URLColor = .custom.highContrast
+            label.emailColor = .custom.highContrast
+            label.backgroundColor = self.contentView.backgroundColor
+        }
         
         self.profilePic.onThemeChange()
         self.header.onThemeChange()

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -133,7 +133,6 @@ class PostCardHeader: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setupUI()
-        NotificationCenter.default.addObserver(self, selector: #selector(self.stopTimeUpdates), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -168,8 +167,14 @@ class PostCardHeader: UIView {
             headerMainTitleStackView.removeArrangedSubview(followButton)
             followButton.removeFromSuperview()
         }
+    }
+    
+    func setupUIFromSettings() {
+        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
+        userTagLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
+        dateLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
         
-        setupUIFromSettings()
+        self.onThemeChange()
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -134,7 +134,6 @@ class PostCardHeader: UIView {
         super.init(frame: frame)
         self.setupUI()
         NotificationCenter.default.addObserver(self, selector: #selector(self.stopTimeUpdates), name: UIApplication.didEnterBackgroundNotification, object: nil)
-
     }
     
     required init?(coder: NSCoder) {
@@ -171,7 +170,6 @@ class PostCardHeader: UIView {
         }
         
         setupUIFromSettings()
-        self.stopTimeUpdates()
     }
 }
 
@@ -212,12 +210,6 @@ private extension PostCardHeader {
         
         setupUIFromSettings()
     }
-    
-    func setupUIFromSettings() {
-        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
-        userTagLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
-        dateLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
-    }    
 }
 
 // MARK: - Configuration

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -167,6 +167,8 @@ class PostCardHeader: UIView {
             headerMainTitleStackView.removeArrangedSubview(followButton)
             followButton.removeFromSuperview()
         }
+        
+        self.stopTimeUpdates()
     }
     
     func setupUIFromSettings() {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
@@ -48,7 +48,10 @@ class PostCardHeaderExtension: UIView {
         self.postCard = nil
         self.onPress = nil
         self.titleLabel.text = nil
-        setupUIFromSettings()
+    }
+    
+    func setupUIFromSettings() {
+        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 }
 
@@ -67,10 +70,6 @@ private extension PostCardHeaderExtension {
         
         mainStackView.addArrangedSubview(titleLabel)
         setupUIFromSettings()
-    }
-    
-    func setupUIFromSettings() {
-        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
@@ -112,7 +112,11 @@ class PostCardLinkPreview: UIView {
         self.imageView.removeFromSuperview()
         self.imageHeightConstraint?.isActive = false
         self.onPress = nil
-        setupUIFromSettings()
+    }
+    
+    func setupUIFromSettings() {
+        urlLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
+        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
     }
 }
 
@@ -151,11 +155,6 @@ private extension PostCardLinkPreview {
         ])
         
         setupUIFromSettings()
-    }
-    
-    func setupUIFromSettings() {
-        urlLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
-        titleLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .semibold)
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
@@ -76,8 +76,6 @@ final class PostCardMetadata: UIView {
             metricsStackView.removeArrangedSubview(viewDetailsLabel)
             viewDetailsLabel.removeFromSuperview()
         }
-        
-        setupUIFromSettings()
     }
     
     func setupUIFromSettings() {
@@ -108,6 +106,8 @@ final class PostCardMetadata: UIView {
         likesLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.onMetricPress)))
         repostsLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.onMetricPress)))
         repliesLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.onMetricPress)))
+        
+        self.setupUIFromSettings()
     }
     
     func configure(postCard: PostCardModel, type: PostCardCell.PostCardCellType = .regular, onButtonPress: @escaping PostCardButtonCallback) {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -184,8 +184,10 @@ class PostCardQuotePost: UIView {
             postLoader.removeFromSuperview()
             self.postLoaderTrailingConstraint?.isActive = false
         }
-
-        setupUIFromSettings()
+    }
+    
+    func setupUIFromSettings() {
+        postTextLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 }
 
@@ -215,10 +217,6 @@ private extension PostCardQuotePost {
         ])
         
         setupUIFromSettings()
-    }
-
-    func setupUIFromSettings() {
-        postTextLabel.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular)
     }
 }
 


### PR DESCRIPTION
When setting properties (eg. hashtagColor) on ActiveLabel, an expensive internal method `updateTextStorage` is being called. Limit these updates to a minimum, and when called, batch them using ActiveLabel's `customize` closure.

https://linear.app/theblvd/issue/MAM-3480/performance-update-activelabel-less-often