### PR TITLE
MAM-3472-remove-opt-out-behavior-for-mammoth-in-onboarding

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -655,6 +655,8 @@
 		BFDE45972B16CFB30055480A /* About.rtf in Resources */ = {isa = PBXBuildFile; fileRef = BFDE45962B16CFB30055480A /* About.rtf */; };
 		BFE5A3072A02C7BD004CBD9F /* URL+Mastodon.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE5A3062A02C7BD004CBD9F /* URL+Mastodon.swift */; };
 		BFE721AB2A58A6960028F78F /* AccountSwitcherButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE721AA2A58A6960028F78F /* AccountSwitcherButton.swift */; };
+		BFEA73292B2A4A5600A0D032 /* SetupMammothViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEA73272B2A4A5600A0D032 /* SetupMammothViewController.swift */; };
+		BFEA732A2B2A4A5600A0D032 /* SetupMammothViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEA73282B2A4A5600A0D032 /* SetupMammothViewModel.swift */; };
 		BFF7B5BA29FC43B400B29D94 /* ComposeQuotePostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF7B5B929FC43B400B29D94 /* ComposeQuotePostCell.swift */; };
 		BFF8FA502AF1AD85004D3553 /* ForYouCustomizationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF8FA4F2AF1AD85004D3553 /* ForYouCustomizationHeader.swift */; };
 		C3085A042AC42EEF007E1CFD /* PostCardMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3085A032AC42EEF007E1CFD /* PostCardMetadata.swift */; };
@@ -1484,6 +1486,8 @@
 		BFDE45962B16CFB30055480A /* About.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = About.rtf; sourceTree = "<group>"; };
 		BFE5A3062A02C7BD004CBD9F /* URL+Mastodon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Mastodon.swift"; sourceTree = "<group>"; };
 		BFE721AA2A58A6960028F78F /* AccountSwitcherButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitcherButton.swift; sourceTree = "<group>"; };
+		BFEA73272B2A4A5600A0D032 /* SetupMammothViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupMammothViewController.swift; sourceTree = "<group>"; };
+		BFEA73282B2A4A5600A0D032 /* SetupMammothViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupMammothViewModel.swift; sourceTree = "<group>"; };
 		BFF77EC629BD58DA00DFDE26 /* Version Info */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Version Info"; sourceTree = "<group>"; };
 		BFF7B5B929FC43B400B29D94 /* ComposeQuotePostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeQuotePostCell.swift; sourceTree = "<group>"; };
 		BFF8FA4F2AF1AD85004D3553 /* ForYouCustomizationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForYouCustomizationHeader.swift; sourceTree = "<group>"; };
@@ -2167,6 +2171,8 @@
 				BF7F46F82AD48AEB000977EB /* SetupChannelsViewModel.swift */,
 				BF7F46FE2AD4A73F000977EB /* SetupAccountsViewController.swift */,
 				BF7F47002AD4AA32000977EB /* SetupAccountsViewModel.swift */,
+				BFEA73272B2A4A5600A0D032 /* SetupMammothViewController.swift */,
+				BFEA73282B2A4A5600A0D032 /* SetupMammothViewModel.swift */,
 				BF7F46FC2AD48FA0000977EB /* SetupInstructionsCell.swift */,
 				BF7F46FA2AD48F71000977EB /* SetupInstructionsCell.xib */,
 				5339946D2914214A00560F83 /* SignInViewController.swift */,
@@ -3847,6 +3853,7 @@
 				C37881D12A20D2D90053A586 /* StatusService.swift in Sources */,
 				5339963F2914227A00560F83 /* GlobalStruct.swift in Sources */,
 				53399A78291526B900560F83 /* RequestRange.swift in Sources */,
+				BFEA73292B2A4A5600A0D032 /* SetupMammothViewController.swift in Sources */,
 				53B15861293F66D20026E90B /* Decode85.swift in Sources */,
 				BF0DC4AD2A1C22170072C1DA /* HomeViewController.swift in Sources */,
 				533996742914227A00560F83 /* SKPhotoBrowser.swift in Sources */,
@@ -3991,6 +3998,7 @@
 				534118592960B7F200696DDA /* MessageDisclaimerCell.swift in Sources */,
 				53399A33291526B900560F83 /* PaginationItem.swift in Sources */,
 				BF9325802A451B280034CAE7 /* ProfileImage.swift in Sources */,
+				BFEA732A2B2A4A5600A0D032 /* SetupMammothViewModel.swift in Sources */,
 				662B60EC2A4A1EFC00CB331F /* BlueskyAPI.swift in Sources */,
 				53B15869294227650026E90B /* FilterDetailsViewController.swift in Sources */,
 				53399A3F291526B900560F83 /* HTTPURLResponse.swift in Sources */,

--- a/Mammoth/AppCoordinator.swift
+++ b/Mammoth/AppCoordinator.swift
@@ -82,6 +82,7 @@ class AppCoordinator {
         // Give these a chance to preload
         SetupChannelsViewModel.preload()
         SetupAccountsViewModel.preload()
+        SetupMammothViewModel.preload()
         // Show the first onboarding screen
         let setupChannelsNavVC = UINavigationController(rootViewController: SetupChannelsViewController())
         if isOverlay {

--- a/Mammoth/Screens/Registration/SetupAccountsViewController.swift
+++ b/Mammoth/Screens/Registration/SetupAccountsViewController.swift
@@ -99,6 +99,9 @@ class SetupAccountsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+        
+        let doneButtonTitle = SetupMammothViewModel.shared.shouldShow() ? "Next" : "Done"
+        doneButton.setTitle(doneButtonTitle, for: .normal)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Mammoth/Screens/Registration/SetupAccountsViewModel.swift
+++ b/Mammoth/Screens/Registration/SetupAccountsViewModel.swift
@@ -138,6 +138,15 @@ extension SetupAccountsViewModel {
                         return nil
                     }
                 }
+                
+                // We used to include mammoth@moth.social in the list, but not anymore.
+                // If it's in this category, and it's the only one, go ahead
+                // and just skip this category altogether.
+                if accounts.count == 1, accounts[0] == mammothAccount {
+                    log.debug("skipping category with just the mammoth@moth.social account")
+                    continue
+                }
+                
                 let userCards = accounts.map({ account in
                     UserCardModel.fromAccount(account: account, instanceName: GlobalHostServer())
                 })
@@ -158,14 +167,7 @@ extension SetupAccountsViewModel {
                 newListHeaders.append(categoryFromServer.name)
                 newListData.append(userCards)
             }
-            
-            if let mammothAccount {
-                await MainActor.run {
-                    // Subscribe to @Mammoth if present
-                    FollowManager.shared.followAccount(mammothAccount)
-                }
-            }
-            
+                        
             let newHeaders = newListHeaders
             let newData = newListData
             await MainActor.run {

--- a/Mammoth/Screens/Registration/SetupMammothViewController.swift
+++ b/Mammoth/Screens/Registration/SetupMammothViewController.swift
@@ -1,14 +1,14 @@
 //
-//  SetupAccountsViewController.swift
+//  SetupMammothViewController.swift
 //  Mammoth
 //
-//  Created by Riley Howard on 10/9/23.
+//  Created by Riley Howard on 10/13/23.
 //  Copyright © 2023 The BLVD. All rights reserved.
 //
 
 import UIKit
 
-class SetupAccountsViewController: UIViewController {
+class SetupMammothViewController: UIViewController {
 
     private lazy var navHeader: UIView = {
         let navHeader = UIView()
@@ -44,10 +44,19 @@ class SetupAccountsViewController: UIViewController {
         return loader;
     }()
 
+    private lazy var noThanksButton: UIButton = {
+        let noThanksButton = UIButton()
+        noThanksButton.translatesAutoresizingMaskIntoConstraints = false
+        noThanksButton.setTitle("No thanks", for: .normal)
+        noThanksButton.backgroundColor = .clear
+        noThanksButton.setTitleColor(.custom.mediumContrast, for: .normal)
+        return noThanksButton
+    }()
+
     private lazy var doneButton: UIButton = {
         let doneButton = UIButton()
         doneButton.translatesAutoresizingMaskIntoConstraints = false
-        doneButton.setTitle("Next", for: .normal)
+        doneButton.setTitle("Follow Mammoth", for: .normal)
         doneButton.backgroundColor = .custom.OVRLYMedContrast
         doneButton.setTitleColor(.custom.highContrast, for: .normal)
         doneButton.layer.cornerRadius = 8
@@ -61,8 +70,8 @@ class SetupAccountsViewController: UIViewController {
         return doneButtonBackground
     }()
 
-    private var viewModel = SetupAccountsViewModel.shared
-
+    private var viewModel = SetupMammothViewModel.shared
+    
     required init() {
         super.init(nibName: nil, bundle: nil)
         self.isModalInPresentation = true
@@ -74,7 +83,6 @@ class SetupAccountsViewController: UIViewController {
     }
     
     deinit {
-        self.viewModel.cancelAllItemSyncs()
         NotificationCenter.default.removeObserver(self)
     }
     
@@ -104,7 +112,6 @@ class SetupAccountsViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
-        self.viewModel.cancelAllItemSyncs()
     }
 
     @objc private func onThemeChange() {
@@ -113,7 +120,7 @@ class SetupAccountsViewController: UIViewController {
 }
 
 // MARK: UI Setup
-private extension SetupAccountsViewController {
+private extension SetupMammothViewController {
     func setupUI() {
         if UIDevice.current.userInterfaceIdiom == .phone {
             self.view.layoutMargins = .init(top: 0, left: 0, bottom: 0, right: 0)
@@ -128,8 +135,12 @@ private extension SetupAccountsViewController {
             navHeader.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
         ])
 
-        doneButton.addTarget(self, action: #selector(self.doneTapped), for: .touchUpInside)
+        doneButton.addTarget(self, action: #selector(self.followMammothTapped), for: .touchUpInside)
         doneButtonBackground.addSubview(doneButton)
+        
+        noThanksButton.addTarget(self, action: #selector(self.noThanksTapped), for: .touchUpInside)
+        doneButtonBackground.addSubview(noThanksButton)
+
         view.addSubview(doneButtonBackground)
         NSLayoutConstraint.activate([
             doneButtonBackground.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
@@ -138,11 +149,17 @@ private extension SetupAccountsViewController {
 
             doneButton.leadingAnchor.constraint(equalTo: doneButtonBackground.leadingAnchor, constant: 13),
             doneButton.trailingAnchor.constraint(equalTo: doneButtonBackground.trailingAnchor, constant: -13),
-            doneButton.topAnchor.constraint(equalTo: doneButtonBackground.topAnchor, constant: 13),
             doneButton.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor),
             doneButton.heightAnchor.constraint(equalToConstant: 50),
+
+            noThanksButton.leadingAnchor.constraint(equalTo: doneButtonBackground.leadingAnchor, constant: 13),
+            noThanksButton.trailingAnchor.constraint(equalTo: doneButtonBackground.trailingAnchor, constant: -13),
+            noThanksButton.bottomAnchor.constraint(equalTo: doneButton.topAnchor, constant: -1),
+            noThanksButton.heightAnchor.constraint(equalToConstant: 50),
+
+            noThanksButton.topAnchor.constraint(equalTo: doneButtonBackground.topAnchor, constant: 13),
         ])
-        
+                
         view.addSubview(tableView)
         view.addSubview(loader)
         
@@ -162,15 +179,7 @@ private extension SetupAccountsViewController {
 }
 
 // MARK: UITableViewDataSource & UITableViewDelegate
-extension SetupAccountsViewController: UITableViewDataSource, UITableViewDelegate {
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        self.viewModel.requestItemSync(forIndexPath: indexPath, afterSeconds: 1)
-    }
-    
-    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        self.viewModel.cancelItemSync(forIndexPath: indexPath)
-    }
-    
+extension SetupMammothViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfItems(forSection: section)
     }
@@ -190,13 +199,13 @@ extension SetupAccountsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             let cell = self.tableView.dequeueReusableCell(withIdentifier: SetupInstructionsCell.reuseIdentifier) as! SetupInstructionsCell
-            cell.configure(title: "Follow suggestions for you", instructions: "The more people you follow the better our recommendations will get. You can see more recommendations later in the Discover tab.")
+            cell.configure(title: "Find out what's coming next", instructions: "Have a feature you want to see? Want to know what we’re working on next? Or just have a question? Follow us!")
             return cell
         } else {
             if let userCard = viewModel.getInfo(forIndexPath: indexPath) {
                 userCard.forceFollowButtonDisplay = true
                 let cell = self.tableView.dequeueReusableCell(withIdentifier: UserCardCell.reuseIdentifier, for: indexPath) as! UserCardCell
-                cell.configure(info: userCard, actionButtonType: .follow) { [weak self] (type, isActive, data) in
+                cell.configure(info: userCard, actionButtonType: .none) { [weak self] (type, isActive, data) in
                     guard let self else { return }
                     if type == .profile {
                         displayUserProfile(user: userCard)
@@ -239,7 +248,7 @@ extension SetupAccountsViewController: UITableViewDataSource, UITableViewDelegat
 }
 
 // MARK: RequestDelegate
-extension SetupAccountsViewController: RequestDelegate {
+extension SetupMammothViewController: RequestDelegate {
     func didUpdate(with state: ViewState) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
@@ -260,7 +269,7 @@ extension SetupAccountsViewController: RequestDelegate {
             case .error(let error):
                 self.loader.stopAnimating()
                 self.loader.isHidden = true
-                log.error("Error on SetupAccountsViewController didUpdate: \(state) - \(error)")
+                log.error("Error on SetupMammothViewController didUpdate: \(state) - \(error)")
                 break
             }
         }
@@ -275,18 +284,21 @@ extension SetupAccountsViewController: RequestDelegate {
     }
 }
 
-extension SetupAccountsViewController {
-    @objc func doneTapped() {
-        if SetupMammothViewModel.shared.shouldShow() {
-            // Go to the next screen
-            let vc = SetupMammothViewController()
-            self.navigationController?.pushViewController(vc, animated: true)
-        } else {
-            // All done
-            // Clear out the onboarding flag
-            AccountsManager.shared.didShowOnboardingForCurrentAccount()
-            // Exit the signup flow
-            NotificationCenter.default.post(name: shouldChangeRootViewController, object: nil)
-        }
+extension SetupMammothViewController {
+    
+    @objc func noThanksTapped() {
+        goToNextPane()
+    }
+    
+    @objc func followMammothTapped() {
+        self.viewModel.followMammothAccount()
+        goToNextPane()
+    }
+    
+    private func goToNextPane() {
+        // Clear out the onboarding flag
+        AccountsManager.shared.didShowOnboardingForCurrentAccount()
+        // Exit the signup flow
+        NotificationCenter.default.post(name: shouldChangeRootViewController, object: nil)
     }
 }

--- a/Mammoth/Screens/Registration/SetupMammothViewModel.swift
+++ b/Mammoth/Screens/Registration/SetupMammothViewModel.swift
@@ -1,0 +1,139 @@
+//
+//  SetupMammothViewModel.swift
+//  Mammoth
+//
+//  Created by Riley Howard on 10/13/23.
+//  Copyright © 2023 The BLVD. All rights reserved.
+//
+
+import Foundation
+
+class SetupMammothViewModel {
+    
+    private enum ViewTypes: Int, CaseIterable {
+        case regular
+        case typing
+        case searchResult
+    }
+    
+    static let shared = SetupMammothViewModel()
+    static func preload() {
+        _ = self.shared
+    }
+
+    weak var delegate: RequestDelegate? {
+        didSet {
+            self.delegate?.didUpdate(with: state)
+        }
+    }
+    
+    private var type: ViewTypes = .regular
+    private var state: ViewState {
+        didSet {
+            self.delegate?.didUpdate(with: state)
+        }
+    }
+    
+    private var listDataHeaders: [String] = []
+    private var listData: UserCardModel? = nil
+    private var postSyncingTasks: [IndexPath: Task<Void, Error>] = [:]
+
+    init() {
+        self.state = .idle
+                
+        Task {
+            await self.loadRecommendations()
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // Always show this screen, unless we are sure the
+    // current account already follows Mammoth
+    public func shouldShow() -> Bool {
+        guard let mammothAccount = listData?.account else {
+            return true
+        }
+        let followStatus = FollowManager.shared.followStatusForAccount(mammothAccount)
+        return followStatus != .following
+    }
+}
+
+// MARK: - DataSource
+extension SetupMammothViewModel {
+    func numberOfItems(forSection section: Int) -> Int {
+        if section == 0 {
+            return 1
+        } else {
+            return self.listData == nil ? 0 : 1
+        }
+    }
+    
+    var numberOfSections: Int {
+        return 2
+    }
+    
+    func hasHeader(forSection sectionIndex: Int) -> Bool {
+        return false
+    }
+    
+    func shouldSyncFollowStatus() -> Bool {
+        return false
+    }
+
+    func getInfo(forIndexPath indexPath: IndexPath) -> UserCardModel? {
+        guard indexPath.section > 0 else { return nil } // The first section is the header / no data
+        return self.listData
+    }
+    
+    func getSectionTitle(for sectionIndex: Int) -> String {
+        return ""
+    }
+
+}
+
+// MARK: - Service
+extension SetupMammothViewModel {
+    func loadRecommendations() async {
+        self.state = .loading
+        
+        // Load the info for the Mammoth account
+        guard let mammothAccount = await AccountService.lookup("mammoth", serverName: "moth.social") else {
+            log.error("unable to get Mammoth account info")
+            let error = NSError(domain: "Unable to get Mammoth account info", code: 100)
+            self.state = .error(error)
+            return
+        }
+        let mammothUserCard = UserCardModel(account: mammothAccount)
+        await MainActor.run {
+            self.listData = mammothUserCard
+            self.state = .success
+        }
+        
+        // Update the follow status for this account if not yet known
+        let followStatus = FollowManager.shared.followStatusForAccount(mammothAccount, requestUpdate: .whenUncertain)
+    }
+    
+    func followMammothAccount() {
+        // Follow @mammoth if we already have the account info;
+        // otherwise, go get it, and then follow.
+        Task {
+            var mammothAccount = self.listData?.account
+            if mammothAccount == nil {
+                mammothAccount = await AccountService.lookup("mammoth", serverName: "moth.social")
+            }
+            if let mammothAccount {
+                await MainActor.run {
+                    FollowManager.shared.followAccount(mammothAccount)
+                }
+            } else {
+                log.error("Unable to get Mammoth account info ")
+            }
+        }
+    }
+
+    
+}
+

--- a/Mammoth/Screens/Registration/SetupProfileController.swift
+++ b/Mammoth/Screens/Registration/SetupProfileController.swift
@@ -69,6 +69,7 @@ class SetupProfileController: UIViewController {
         // Give these a chance to preload
         SetupChannelsViewModel.preload()
         SetupAccountsViewModel.preload()
+        SetupMammothViewModel.preload()
     }
 
     

--- a/Mammoth/Screens/Registration/SignInViewController.swift
+++ b/Mammoth/Screens/Registration/SignInViewController.swift
@@ -629,6 +629,12 @@ class SignInViewController: UIViewController, UITableViewDataSource, UITableView
                             alert.dismiss(animated: false)
                             // User is successfullly signed in. Present them with the
                             // option to subscribe to a smart list.
+
+                            // Give these a chance to preload
+                            SetupChannelsViewModel.preload()
+                            SetupAccountsViewModel.preload()
+                            SetupMammothViewModel.preload()
+
                             let vc = SetupChannelsViewController()
                             self.navigationController?.pushViewController(vc, animated: true)
                         } else {


### PR DESCRIPTION
- add third onboarding pane for Follow Mammoth
- filter mammoth@moth.social out of the list of suggested accounts
- no longer default to following mammoth@moth.social (was opt-out)
- skip suggesting following Mammoth if we're certain the user is already following it