### PR TITLE
MAM-3497-make-switching-post-language-easier-more-user-friendly

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		BF33A0F42AA946AF0008D9DF /* ThinSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF33A0F32AA946AF0008D9DF /* ThinSlider.swift */; };
 		BF34B1A62A0E9774002F3FED /* HashtagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF34B1A52A0E9774002F3FED /* HashtagManager.swift */; };
 		BF3841F32AD6F39A005C3995 /* EmailHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3841F22AD6F39A005C3995 /* EmailHandler.swift */; };
+		BF44B2D62B2D29F400442F61 /* PostLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF44B2D52B2D29F400442F61 /* PostLanguages.swift */; };
 		BF48B9322A8FE54F00DE6BFC /* ToastNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48B9312A8FE54F00DE6BFC /* ToastNotification.swift */; };
 		BF492DAE29F1E04C004100B8 /* QuotePostMutedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF492DAD29F1E04C004100B8 /* QuotePostMutedView.swift */; };
 		BF492DB029F21811004100B8 /* QuotePostMutedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BF492DAF29F21811004100B8 /* QuotePostMutedView.xib */; };
@@ -1416,6 +1417,7 @@
 		BF33A0F32AA946AF0008D9DF /* ThinSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinSlider.swift; sourceTree = "<group>"; };
 		BF34B1A52A0E9774002F3FED /* HashtagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagManager.swift; sourceTree = "<group>"; };
 		BF3841F22AD6F39A005C3995 /* EmailHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailHandler.swift; sourceTree = "<group>"; };
+		BF44B2D52B2D29F400442F61 /* PostLanguages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLanguages.swift; sourceTree = "<group>"; };
 		BF48B9312A8FE54F00DE6BFC /* ToastNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastNotification.swift; sourceTree = "<group>"; };
 		BF492DAD29F1E04C004100B8 /* QuotePostMutedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotePostMutedView.swift; sourceTree = "<group>"; };
 		BF492DAF29F21811004100B8 /* QuotePostMutedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuotePostMutedView.xib; sourceTree = "<group>"; };
@@ -2682,6 +2684,7 @@
 				C354D6032A0D1AF300F8AC04 /* ViewState.swift */,
 				C376357B2A55974F0008DD21 /* NewsFeedListItem.swift */,
 				BFA71B542AB23A70001D1EC1 /* InstanceCardModel.swift */,
+				BF44B2D52B2D29F400442F61 /* PostLanguages.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3648,6 +3651,7 @@
 				5339947F2914214A00560F83 /* IconSettingsViewController.swift in Sources */,
 				533994C72914214A00560F83 /* ProfileNoteViewController.swift in Sources */,
 				BF0C9DEE299946C50046D072 /* Log.swift in Sources */,
+				BF44B2D62B2D29F400442F61 /* PostLanguages.swift in Sources */,
 				C3C22E762A39C1F100C7CB0A /* ProfileCoverImage.swift in Sources */,
 				53450E422936121600D720EA /* GiphySimpleItem.swift in Sources */,
 				532F286F29449DBF003C9FAD /* ChatMessageViewController.swift in Sources */,

--- a/Mammoth/Models/GlobalStruct.swift
+++ b/Mammoth/Models/GlobalStruct.swift
@@ -48,8 +48,7 @@ public struct GlobalStruct {
     static var switchingAccount4: Bool = false
     static var circleProfiles: Bool = true
     static var chatView: Bool = true
-    static var currentPostLang: String? = nil
-    static var currentPostLang2: String? = nil
+    static var currentPostLang2: String? = nil // used to set the user's profile language
     static var tabTapRestore: Bool = true
     static var hasSetupNewsDots: Bool = false
     static var fullScreen: Bool = true

--- a/Mammoth/Models/PostLanguages.swift
+++ b/Mammoth/Models/PostLanguages.swift
@@ -1,0 +1,65 @@
+//
+//  PostLanguages.swift
+//  Mammoth
+//
+//  Created by Riley on 12/15/23
+//  Copyright © 2023 The BLVD. All rights reserved.
+//
+
+import Foundation
+
+class PostLanguages {
+    
+    static var shared = PostLanguages()
+    
+    private (set) var postLanguage: String {
+        didSet {
+            UserDefaults.standard.setValue(postLanguage, forKey: "postLanguages")
+        }
+    }
+    private (set) var postLanguages: [String] {
+        didSet {
+            UserDefaults.standard.setValue(postLanguages, forKey: "postLanguages")
+        }
+    }
+    
+    init() {
+        postLanguage = UserDefaults.standard.value(forKey: "postLanguage") as? String ?? Locale.current.languageCode ?? "EN"
+        postLanguages = UserDefaults.standard.value(forKey: "postLanguages") as? [String] ?? []
+        if postLanguages.count == 0 {
+            postLanguages = [postLanguage]
+        }
+        if !postLanguages.contains(postLanguage) {
+            postLanguages.append(postLanguage)
+        }
+    }
+        
+    // Will add if needed, and also move the language to the start of the array
+    public func selectPostLanguage(_ language: String) {
+        // First, add to the list if necessary
+        if !postLanguages.contains(language) {
+            postLanguages.append(language)
+            // Trim to 3 most recent languages
+            while postLanguages.count > 3 {
+                postLanguages.removeFirst()
+            }
+        }
+        
+        // Then select it
+        postLanguage = language
+    }
+    
+    // Will remove the language, unless it is the last one
+    public func removePostLanguage(_ language: String) {
+        if postLanguages.count > 1 {
+            if let index = postLanguages.firstIndex(of: language) {
+                postLanguages.remove(at: index)
+            }
+        }
+        if !postLanguages.contains(postLanguage) {
+            postLanguage = postLanguages[0]
+        }
+    }
+    
+}
+

--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -73,7 +73,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
     var mediaAttached: Bool = false // Looks like this is never cleared (?)
     var hasEditedText = false
     var hasEditedMedia = false
-    var hasEditedMedtadata = false // CW, Sensitive, Post Language
+    var hasEditedMetadata = false // CW, Sensitive, Post Language
     var hasEditedPoll = false
     let numImages = 4
     var imageButton = [UIButton(), UIButton(), UIButton(), UIButton()]
@@ -1139,7 +1139,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
             }
             vie1.accessibilityLabel = "View Image"
             let alt1 = UIAction(title: "Add Image Description", image: UIImage(systemName: "character.cursor.ibeam"), identifier: nil) { action in
-                self.hasEditedMedtadata = true
+                self.hasEditedMetadata = true
                 let vc = AltTextViewController()
                 vc.currentImage = self.imageButton[0].currentImage ?? UIImage()
                 if let x = GlobalStruct.altAdded[0] {
@@ -1237,7 +1237,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
                 }
                 vie2.accessibilityLabel = "View Image"
                 let alt2 = UIAction(title: "Add Image Description", image: UIImage(systemName: "character.cursor.ibeam"), identifier: nil) { action in
-                    self.hasEditedMedtadata = true
+                    self.hasEditedMetadata = true
                     let vc = AltTextViewController()
                     vc.currentImage = self.imageButton[index].currentImage ?? UIImage()
                     if let x = GlobalStruct.altAdded[index] {
@@ -1535,7 +1535,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
     @objc func cwTapped() {
-        self.hasEditedMedtadata = true
+        self.hasEditedMetadata = true
         if self.cwHeight == 0 {
             self.cwHeight = UITableView.automaticDimension
             self.tableView.reloadRows(at: [IndexPath(row: 0, section: 1)], with: .bottom)
@@ -1589,7 +1589,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
             sensitiveImage = "exclamationmark.triangle.fill"
         }
         let viewSensitive = UIAction(title: sensitiveText, image: UIImage(systemName: sensitiveImage), identifier: nil) { action in
-            self.hasEditedMedtadata = true
+            self.hasEditedMetadata = true
             self.isSensitive = !self.isSensitive
             self.itemLastMenu()
             self.updatePostButton()
@@ -2853,7 +2853,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
     @objc func textFieldDidChange(_ textField: UITextField) {
-        self.hasEditedMedtadata = true
+        self.hasEditedMetadata = true
         self.updateCharacterCounts()
         if let cell2 = self.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? AltTextCell2 {
             self.spoilerText = cell2.altText.text ?? ""
@@ -3480,7 +3480,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
             // Enable if (1) there is any valid content, AND
             //           (2) any editing has happened
             let canSend = hasAnyValidContent &&
-                            (self.hasEditedText || self.hasEditedMedia || self.hasEditedMedtadata || self.hasEditedPoll)
+                            (self.hasEditedText || self.hasEditedMedia || self.hasEditedMetadata || self.hasEditedPoll)
             if canSend {
                 let symbolConfig0 = UIImage.SymbolConfiguration(pointSize: 24, weight: .bold)
                 self.canPost = true
@@ -3937,7 +3937,7 @@ extension NewPostViewController: TranslationComposeViewControllerDelegate {
     }
         
     @objc func menuShowLanguagePicker() {
-        self.hasEditedMedtadata = true
+        self.hasEditedMetadata = true
         self.updatePostButton()
         let vc = TranslationComposeViewController()
         vc.fromSetLanguage = true

--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -3898,7 +3898,6 @@ extension NewPostViewController: TranslationComposeViewControllerDelegate {
             let pickLanguageAction = UIAction(title:languageName, image: nil, identifier: nil) { [weak self] _ in
                 self?.menuSelectLanguage(language)
             }
-            pickLanguageAction.state = (language == PostLanguages.shared.postLanguage) ? .on : .off
             menuItems.append(pickLanguageAction)
         }
         let buttonMenu = UIMenu(title: "", image: nil, identifier: nil, options: [], children: menuItems)

--- a/Mammoth/Screens/Composer/TranslationComposeViewController.swift
+++ b/Mammoth/Screens/Composer/TranslationComposeViewController.swift
@@ -11,6 +11,13 @@ import UIKit
 import NaturalLanguage
 import OrderedCollections
 
+protocol TranslationComposeViewControllerDelegate: AnyObject {
+    func didSelectLanguage(language: String)
+    func removeLanguage(language: String)
+}
+
+
+
 class TranslationComposeViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, TableOfContentsSelectionDelegate {
     
     let btn0 = UIButton(type: .custom)
@@ -23,6 +30,7 @@ class TranslationComposeViewController: UIViewController, UITableViewDataSource,
     var prefLang: [String] = []
     var fromSetLanguage: Bool = false
     var fromEditProfile: Bool = false
+    weak var delegate: TranslationComposeViewControllerDelegate?
     
     let tableOfContentsSelector1 = TableOfContentsSelector()
     
@@ -67,7 +75,8 @@ class TranslationComposeViewController: UIViewController, UITableViewDataSource,
     }
     
     @objc func removeTap() {
-        GlobalStruct.currentPostLang = nil
+        let currentLanguage = PostLanguages.shared.postLanguage
+        self.delegate?.removeLanguage(language: currentLanguage)
         self.dismissTap()
     }
     
@@ -263,7 +272,7 @@ class TranslationComposeViewController: UIViewController, UITableViewDataSource,
             cell.textLabel?.text = Array(self.firstSection.keys)[indexPath.row]
             cell.backgroundColor = .custom.quoteTint
             if self.fromSetLanguage {
-                if GlobalStruct.currentPostLang == Array(self.firstSection.values)[indexPath.row] {
+                if PostLanguages.shared.postLanguage == Array(self.firstSection.values)[indexPath.row] {
                     cell.accessoryType = .checkmark
                 } else {
                     cell.accessoryType = .none
@@ -317,7 +326,7 @@ class TranslationComposeViewController: UIViewController, UITableViewDataSource,
         } else {
             if self.fromSetLanguage {
                 self.langStr = Array(self.firstSection.values)[indexPath.row]
-                GlobalStruct.currentPostLang = self.langStr
+                delegate?.didSelectLanguage(language: self.langStr)
                 self.dismiss(animated: true, completion: nil)
             } else {
                 if indexPath.section == 0 {


### PR DESCRIPTION
- added PostLanguages class
- added TranslationComposeViewControllerDelegate
- extended NewPostViewController to add a language button
- removed the postLanguage global