### PR TITLE
MAM-3561-investigate-account-language-setting-and-how-to-incorporate-it

### DIFF
--- a/Mammoth/Managers/AccountsManager/AccountsManager.swift
+++ b/Mammoth/Managers/AccountsManager/AccountsManager.swift
@@ -357,7 +357,7 @@ class AccountsManager {
             log.debug("migrating account: \(account.remoteFullOriginalAcct)")
             // Select this account?
             let client = Client(baseURL: "https://\(instance.returnedText)", accessToken: instance.accessToken)
-            let acctData = MastodonAcctData(account: account, instanceData: instance, client: client, defaultPostVisibility: .public, emoticons: [], forYou: ForYouAccount(forYou: ForYouType(), subscribedChannels: []), wentThroughOnboarding: false)
+            let acctData = MastodonAcctData(account: account, instanceData: instance, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount(forYou: ForYouType(), subscribedChannels: []), wentThroughOnboarding: false)
             if instance == InstanceData.getCurrentInstance() {
                 selectedAcctData = acctData
             }

--- a/Mammoth/Managers/AccountsManager/AcctData.swift
+++ b/Mammoth/Managers/AccountsManager/AcctData.swift
@@ -108,6 +108,7 @@ struct MastodonAcctData: AcctDataType {
     let account: Account
     let instanceData: InstanceData
     let defaultPostVisibility: Visibility
+    let defaultPostingLanguage: String?
     let emoticons: [Emoji]
     var forYou: ForYouAccount
     var wentThroughOnboarding: Bool // false for accounts coming from 1.x
@@ -120,18 +121,20 @@ struct MastodonAcctData: AcctDataType {
         case account
         case instanceData
         case defaultPostVisibility
+        case defaultPostLanguage
         case emoticons
         case forYou
         case wentThroughOnboarding
     }
     
-    init(account: Account, instanceData: InstanceData, client: Client, defaultPostVisibility: Visibility, emoticons: [Emoji], forYou: ForYouAccount, uniqueID: String? = nil, wentThroughOnboarding: Bool = false) {
+    init(account: Account, instanceData: InstanceData, client: Client, defaultPostVisibility: Visibility, defaultPostingLanguage: String?, emoticons: [Emoji], forYou: ForYouAccount, uniqueID: String? = nil, wentThroughOnboarding: Bool = false) {
         self.uniqueID = uniqueID ?? UUID().uuidString
         self.account = account
         self.instanceData = instanceData
         self.client = Client(baseURL: "https://\(instanceData.returnedText)", accessToken: instanceData.accessToken)
         self.mothClient = Client(baseURL: "https://\(GlobalHostServer())", accessToken: MothSocialJWT(acct: account.remoteFullOriginalAcct), isMothClient: true)
         self.defaultPostVisibility = defaultPostVisibility
+        self.defaultPostingLanguage = defaultPostingLanguage
         self.emoticons = emoticons
         self.forYou = forYou
         self.wentThroughOnboarding = wentThroughOnboarding
@@ -165,6 +168,12 @@ struct MastodonAcctData: AcctDataType {
         } catch {
             wentThroughOnboarding = false // for 1.x accounts
         }
+        // Below are new for 2.1
+        do {
+            defaultPostingLanguage = try container.decode(type(of: defaultPostingLanguage).self, forKey: .defaultPostVisibility)
+        } catch {
+            defaultPostingLanguage = nil
+        }
         
         _ = try container.superDecoder ( )
     }
@@ -175,6 +184,7 @@ struct MastodonAcctData: AcctDataType {
         try container.encode(account, forKey: .account)
         try container.encode(instanceData, forKey: .instanceData)
         try container.encode(defaultPostVisibility, forKey: .defaultPostVisibility)
+        try container.encode(defaultPostingLanguage, forKey: .defaultPostLanguage)
         try container.encode(emoticons, forKey: .emoticons)
         try container.encode(forYou, forKey: .forYou)
         try container.encode(wentThroughOnboarding, forKey: .wentThroughOnboarding)

--- a/Mammoth/Managers/AccountsManager/AcctHandler.swift
+++ b/Mammoth/Managers/AccountsManager/AcctHandler.swift
@@ -75,7 +75,7 @@ class MastodonAcctHandler: AcctHandler {
                                         completion(error, nil)
                                     }
                                 } else {
-                                    let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
+                                    let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
                                     DispatchQueue.main.async {
                                         completion(nil, newAcct)
                                     }
@@ -124,7 +124,7 @@ class MastodonAcctHandler: AcctHandler {
                 }
             }
             if let account = statuses.value {
-                let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
+                let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
                 DispatchQueue.main.async {
                     completion(nil, newAcct)
                 }
@@ -150,7 +150,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedDisplayName = try await AccountService.updateDisplayName(displayName: displayName)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedDisplayName, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedDisplayName, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -171,7 +171,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedAvatar = try await AccountService.updateAvatar(image: avatar, compressionQuality: 0.5)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedAvatar, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedAvatar, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -192,7 +192,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedHeader = try await AccountService.updateHeader(image: header, compressionQuality: 0.5)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedHeader, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedHeader, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -233,7 +233,9 @@ class MastodonAcctHandler: AcctHandler {
                 postVisiblity = Visibility(rawValue: updatedConstants!.defaultVisibility!) ?? .public
             }
             
-            let updatedMastAcct = MastodonAcctData(account: updatedUser, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: postVisiblity, emoticons: updatedEmojis, forYou: mastodonAcct.forYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let postingLanguage: String? = updatedConstants?.defaultPostingLanguage
+            
+            let updatedMastAcct = MastodonAcctData(account: updatedUser, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: postVisiblity, defaultPostingLanguage: postingLanguage, emoticons: updatedEmojis, forYou: mastodonAcct.forYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
             AccountsManager.shared.updateAccount(updatedMastAcct)
             return updatedMastAcct
         } catch {
@@ -251,7 +253,7 @@ class MastodonAcctHandler: AcctHandler {
         do {
             let getForYou = try await TimelineService.forYouMe(remoteFullOriginalAcct: mastodonAcct.remoteFullOriginalAcct)
 
-            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, emoticons: mastodonAcct.emoticons, forYou: getForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: getForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
             AccountsManager.shared.updateAccount(updatedMastAcct)
             return updatedMastAcct
         } catch {
@@ -270,7 +272,7 @@ class MastodonAcctHandler: AcctHandler {
         do {
             let updatedForYou = try await TimelineService.updateForYouMe(remoteFullOriginalAcct: mastodonAcct.remoteFullOriginalAcct, forYouInfo: forYouInfo)
 
-            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, emoticons: mastodonAcct.emoticons, forYou: updatedForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: updatedForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
             AccountsManager.shared.updateAccount(updatedMastAcct)
             return updatedMastAcct
         } catch {

--- a/Mammoth/Models/PostLanguages.swift
+++ b/Mammoth/Models/PostLanguages.swift
@@ -24,7 +24,10 @@ class PostLanguages {
     }
     
     init() {
-        postLanguage = UserDefaults.standard.value(forKey: "postLanguage") as? String ?? Locale.current.languageCode ?? "EN"
+        postLanguage = UserDefaults.standard.value(forKey: "postLanguage") as? String ??
+                       (AccountsManager.shared.currentAccount as? MastodonAcctData)?.defaultPostingLanguage ??
+                       Locale.current.languageCode ??
+                       "en"
         postLanguages = UserDefaults.standard.value(forKey: "postLanguages") as? [String] ?? []
         if postLanguages.count == 0 {
             postLanguages = [postLanguage]

--- a/Mammoth/Services/Backend/MastodonKit/Models/Instance.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Instance.swift
@@ -101,8 +101,10 @@ public class tagInstanceInfo: Codable {
 
 public class serverConstants: Codable {
     public let defaultVisibility: String?
-    
+    public let defaultPostingLanguage: String?
+
     private enum CodingKeys: String, CodingKey {
         case defaultVisibility = "posting:default:visibility"
+        case defaultPostingLanguage = "posting:default:language"
     }
 }


### PR DESCRIPTION
We now pick the post language in this priority:
1. previously picked language (from prefs), if available
2. default post language from their mastodon profile if available
3. their iOS current language (should always be available)
4. english if all else fails