### PR TITLE
MAM-3524-tapping-on-a-threads-username-yields-user-cant-be-found

### DIFF
--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -99,6 +99,18 @@ final class ProfileViewModel {
                 : serverName
             
             if let account = await AccountService.lookup(fullAcct, serverName: serverName) {
+                // Lookup on account's instance
+                let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
+                await MainActor.run {
+                    user.loadHTMLDescription()
+                    self.user = user
+                }
+                
+                await self.loadListData(type: self.type)
+                
+            } else if let account = await AccountService.lookup(fullAcct, serverName: AccountsManager.shared.currentAccountClient.baseHost) {
+                // Lookup on signed in user's local instance.
+                // This is a fallback for non-mastodon instances
                 let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
                 await MainActor.run {
                     user.loadHTMLDescription()

--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -92,6 +92,12 @@ final class ProfileViewModel {
         // we lookup the account based on the account tag
         Task { [weak self] in
             guard let self else { return }
+            
+            // If server is Threads.net, use the user's local instance
+            let serverName = serverName == "www.threads.net"
+                ? AccountsManager.shared.currentAccountClient.baseHost
+                : serverName
+            
             if let account = await AccountService.lookup(fullAcct, serverName: serverName) {
                 let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
                 await MainActor.run {

--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -100,7 +100,7 @@ final class ProfileViewModel {
             
             if let account = await AccountService.lookup(fullAcct, serverName: serverName) {
                 // Lookup on account's instance
-                let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
+                let user = UserCardModel(account: account, instanceName: serverName, requestFollowStatusUpdate: .force)
                 await MainActor.run {
                     user.loadHTMLDescription()
                     self.user = user
@@ -111,7 +111,7 @@ final class ProfileViewModel {
             } else if let account = await AccountService.lookup(fullAcct, serverName: AccountsManager.shared.currentAccountClient.baseHost) {
                 // Lookup on signed in user's local instance.
                 // This is a fallback for non-mastodon instances
-                let user = UserCardModel(account: account, instanceName: account.server, requestFollowStatusUpdate: .force)
+                let user = UserCardModel(account: account, instanceName: AccountsManager.shared.currentAccountClient.baseHost, requestFollowStatusUpdate: .force)
                 await MainActor.run {
                     user.loadHTMLDescription()
                     self.user = user


### PR DESCRIPTION
https://linear.app/theblvd/issue/MAM-3524/tapping-on-a-threads-username-yields-user-cant-be-found

Also related to https://github.com/TheBLVD/mammoth/issues/191