### PR TITLE
MAM-3571-activity-badges-are-being-clipped

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -69,6 +69,7 @@ final class PostCardProfilePic: UIButton {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.isUserInteractionEnabled = true
         imageView.layer.isOpaque = true
+        imageView.layer.masksToBounds = true
         imageView.layer.backgroundColor = UIColor.custom.background.cgColor
         return imageView
     }()
@@ -144,7 +145,7 @@ private extension PostCardProfilePic {
         let interaction = UIContextMenuInteraction(delegate: self)
         self.profileImageView.addInteraction(interaction)
         
-        self.profileImageView.addSubview(self.badge)
+        self.addSubview(self.badge)
         self.badge.addSubview(self.badgeIconView)
         NSLayoutConstraint.activate([
             self.badge.widthAnchor.constraint(equalToConstant: 22),

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -69,7 +69,6 @@ final class PostCardProfilePic: UIButton {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.isUserInteractionEnabled = true
         imageView.layer.isOpaque = true
-        imageView.layer.masksToBounds = true
         imageView.layer.backgroundColor = UIColor.custom.background.cgColor
         return imageView
     }()


### PR DESCRIPTION
No longer mask to bounds to prevent clipping