### PR TITLE
MAM-3573-tapping-on-avatar-in-activity-doesnt-navigate-to-profile

### DIFF
--- a/Mammoth/Utils/PostActions.swift
+++ b/Mammoth/Utils/PostActions.swift
@@ -205,6 +205,8 @@ struct PostActions {
             
         case .profile:
             switch data {
+            case .user(let userCardModel):
+                PostActions.onProfilePress(target: target, user: userCardModel)
             case .account(let account):
                 PostActions.onProfilePress(target: target, account: account)
             default:


### PR DESCRIPTION
https://linear.app/theblvd/issue/MAM-3573/tapping-on-avatar-in-activity-doesnt-navigate-to-profile