### PR TITLE
MAM-3527-translation-not-working-build-v-202-build-349

### DIFF
--- a/Mammoth/Screens/External/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/Mammoth/Screens/External/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -255,13 +255,6 @@ open class SKPhotoBrowser: UIViewController, UIContextMenuInteractionDelegate, U
         })
     }
     
-    func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
-    }
-    
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return ""
     }

--- a/Mammoth/Screens/GalleryViewController.swift
+++ b/Mammoth/Screens/GalleryViewController.swift
@@ -429,13 +429,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegate, UIColle
         }
     }
     
-    func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
-    }
-    
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return ""
     }

--- a/Mammoth/Utils/PostActions.swift
+++ b/Mammoth/Utils/PostActions.swift
@@ -613,13 +613,7 @@ extension PostActions {
         let unreservedCharset = NSCharacterSet(charactersIn: unreservedChars)
         var trans = bodyText.addingPercentEncoding(withAllowedCharacters: unreservedCharset as CharacterSet)
         trans = trans!.replacingOccurrences(of: "\n\n", with: "%20")
-        var detectedLang = "auto"
-        var tempLanguageCode = ""
-        if bodyText != "" || bodyText != " " {
-            tempLanguageCode = PostActions.detectedLanguage(for: bodyText) ?? "auto"
-            detectedLang = "\(tempLanguageCode.split(separator: "-").first ?? "auto")"
-        }
-        let urlString = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=\(detectedLang)&tl=\(GlobalStruct.langStr)&dt=t&q=\(trans!)&ie=UTF-8&oe=UTF-8"
+        let urlString = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=\(GlobalStruct.langStr)&dt=t&q=\(trans!)&ie=UTF-8&oe=UTF-8"
         guard let requestUrl = URL(string:urlString) else {
             return
         }
@@ -638,8 +632,7 @@ extension PostActions {
                         translatedText = bodyText
                     }
                     DispatchQueue.main.async {
-                        let languageName = Locale.current.localizedString(forLanguageCode: "\(tempLanguageCode)") ?? ""
-                        let alert = UIAlertController(title: nil, message: "\(translatedText)\n\n(Translated from \(languageName))", preferredStyle: .alert)
+                        let alert = UIAlertController(title: nil, message: translatedText, preferredStyle: .alert)
                         alert.addAction(UIAlertAction(title: "Copy", style: .default , handler:{ (UIAlertAction) in
                             UIPasteboard.general.string = translatedText
                         }))
@@ -649,7 +642,7 @@ extension PostActions {
                         let paragraphStyle = NSMutableParagraphStyle()
                         paragraphStyle.alignment = NSTextAlignment.left
                         let messageText = NSMutableAttributedString(
-                            string: "\(translatedText)\n\n(Translated from \(languageName))",
+                            string: translatedText,
                             attributes: [
                                 NSAttributedString.Key.paragraphStyle: paragraphStyle,
                                 NSAttributedString.Key.font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
@@ -668,13 +661,6 @@ extension PostActions {
             }
         }
         task.resume()
-    }
-    
-    static private func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
     }
     
     static func onHashtagPress(target: UIViewController, hashtag: String) {
@@ -1004,13 +990,7 @@ extension PostActions {
         let unreservedCharset = NSCharacterSet(charactersIn: unreservedChars)
         var trans = bodyText.addingPercentEncoding(withAllowedCharacters: unreservedCharset as CharacterSet)
         trans = trans!.replacingOccurrences(of: "\n\n", with: "%20")
-        var detectedLang = "auto"
-        var tempLanguageCode = ""
-        if bodyText != "" || bodyText != " " {
-            tempLanguageCode = PostActions.detectedLanguage(for: bodyText) ?? "auto"
-            detectedLang = "\(tempLanguageCode.split(separator: "-").first ?? "auto")"
-        }
-        let urlString = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=\(detectedLang)&tl=\(GlobalStruct.langStr)&dt=t&q=\(trans!)&ie=UTF-8&oe=UTF-8"
+        let urlString = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=\(GlobalStruct.langStr)&dt=t&q=\(trans!)&ie=UTF-8&oe=UTF-8"
         guard let requestUrl = URL(string:urlString) else {
             return
         }
@@ -1029,8 +1009,7 @@ extension PostActions {
                         translatedText = string
                     }
                     DispatchQueue.main.async {
-                        let languageName = Locale.current.localizedString(forLanguageCode: "\(tempLanguageCode)") ?? ""
-                        let alert = UIAlertController(title: nil, message: "\(translatedText)\n\n(Translated from \(languageName))", preferredStyle: .alert)
+                        let alert = UIAlertController(title: nil, message: translatedText, preferredStyle: .alert)
                         alert.addAction(UIAlertAction(title: "Copy", style: .default , handler:{ (UIAlertAction) in
                             UIPasteboard.general.string = translatedText
                         }))
@@ -1040,7 +1019,7 @@ extension PostActions {
                         let paragraphStyle = NSMutableParagraphStyle()
                         paragraphStyle.alignment = NSTextAlignment.left
                         let messageText = NSMutableAttributedString(
-                            string: "\(translatedText)\n\n(Translated from \(languageName))",
+                            string: translatedText,
                             attributes: [
                                 NSAttributedString.Key.paragraphStyle: paragraphStyle,
                                 NSAttributedString.Key.font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)

--- a/Mammoth/Views/Cells/DetailImageView.swift
+++ b/Mammoth/Views/Cells/DetailImageView.swift
@@ -548,13 +548,6 @@ class DetailImageView: UIView, UICollectionViewDataSource, UICollectionViewDeleg
         return UIMenu(title: "", image: nil, identifier: nil, children: [share, save])
     }
     
-    func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
-    }
-    
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return ""
     }

--- a/Mammoth/Views/Cells/DetailView.swift
+++ b/Mammoth/Views/Cells/DetailView.swift
@@ -963,13 +963,6 @@ class DetailView: UIView, SKPhotoBrowserDelegate, UIActivityItemSource, UIContex
         self.quotePostHostView?.updateForQuotePost(cardURL)
     }
 
-    func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
-    }
-    
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return ""
     }

--- a/Mammoth/Views/Cells/PostView.swift
+++ b/Mammoth/Views/Cells/PostView.swift
@@ -2276,13 +2276,6 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
         }
     }
 
-    func detectedLanguage(for string: String) -> String? {
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(string)
-        guard let languageCode = recognizer.dominantLanguage?.rawValue else { return nil }
-        return languageCode
-    }
-
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return ""
     }


### PR DESCRIPTION
- no longer use NLLanguageRecognizer which doesn't work for some languages (e.g., Latvian)
- don't specify a source language to the translator (use 'auto')
- no longer show the source language in the UI
- remove unused functions detectedLanguage