### PR TITLE
MAM-3593-fix-an-issue-where-sometimes-users-re-experienced-onboarding

### DIFF
--- a/Mammoth/Managers/AccountsManager/AccountsManager.swift
+++ b/Mammoth/Managers/AccountsManager/AccountsManager.swift
@@ -150,9 +150,7 @@ class AccountsManager {
     }
     
     public func updateAccount(_ acctData: (any AcctDataType)) {
-        let existingAcctIndex = allAccounts.firstIndex { existingAcct in
-            existingAcct.uniqueID == acctData.uniqueID
-        }
+        let existingAcctIndex = allAccounts.firstIndex(where: {$0.uniqueID == acctData.uniqueID})
         if existingAcctIndex != nil {
             allAccounts[existingAcctIndex!] = acctData
             self.storeAccountsToDisk()


### PR DESCRIPTION
- fix the use of 'firstIndex' when looking for an account to update