### PR TITLE
MAM-3600-user-reports-that-post-languages-dont-stick-across-app-launches

### DIFF
--- a/Mammoth/Models/PostLanguages.swift
+++ b/Mammoth/Models/PostLanguages.swift
@@ -14,7 +14,7 @@ class PostLanguages {
     
     private (set) var postLanguage: String {
         didSet {
-            UserDefaults.standard.setValue(postLanguage, forKey: "postLanguages")
+            UserDefaults.standard.setValue(postLanguage, forKey: "postLanguage")
         }
     }
     private (set) var postLanguages: [String] {


### PR DESCRIPTION
Store the selected language correctly.
It was using the wrong key (one is postLanguage, and one is postLanguages)