### PR TITLE
MAM-3611-add-support-for-proton-mail

### DIFF
--- a/Mammoth/Utils/EmailHandler.swift
+++ b/Mammoth/Utils/EmailHandler.swift
@@ -72,18 +72,24 @@ class EmailHandler: NSObject {
         let outlookPrefix = "ms-outlook://compose?to=\(destinationEncoded)&subject=\(subjectEncoded)&body=\(bodyEncoded)"
         let yahooMailPrefix = "ymail://mail/compose?to=\(destinationEncoded)&subject=\(subjectEncoded)&body=\(bodyEncoded)"
         let sparkPrefix = "readdle-spark://compose?recipient=\(destinationEncoded)&subject=\(subjectEncoded)&body=\(bodyEncoded)"
+        let protonPrefix = "protonmail://mailto:\(destinationEncoded)?subject=\(subjectEncoded)&body=\(bodyEncoded)"
+        let prefixesToTry = [gmailPrefix, outlookPrefix, yahooMailPrefix, sparkPrefix, protonPrefix]
         
-        if let gmailUrl = URL(string: gmailPrefix) {
-            UIApplication.shared.open(gmailUrl)
-        }
-        if let outlookUrl = URL(string: outlookPrefix) {
-            UIApplication.shared.open(outlookUrl)
-        }
-        if let yahooMail = URL(string: yahooMailPrefix) {
-            UIApplication.shared.open(yahooMail)
-        }
-        if let sparkUrl = URL(string: sparkPrefix) {
-            UIApplication.shared.open(sparkUrl)
+        Task {
+            for prefixToTry in prefixesToTry {
+                if let urlToTry = URL(string: prefixToTry) {
+                    DispatchQueue.main.sync {
+                        UIApplication.shared.open(urlToTry) {success in
+                            if success {
+                                return
+                            }
+                        }
+                    }
+                }
+            }
+            
+            
+            
         }
     }
 }


### PR DESCRIPTION
- added support for Proton URL
- stop iterating over mail apps if there's a success
Annoyingly, Proton strips out the /n from the body (I even tried switching to \r to see if it made a difference; it didn't).

![95DA61B6-2ED9-44F4-B8F5-0DC8C34A9512_1_102_o](https://github.com/TheBLVD/mammoth/assets/13856393/1243a0d5-a23a-44a5-a2b7-d89c59ccbeaa)
