### PR TITLE
MAM-3592-app-icons-lag-when-loadingmisaligned-at-the-bottom

### DIFF
--- a/Mammoth/Screens/Settings/IconSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/IconSettingsViewController.swift
@@ -216,7 +216,7 @@ class IconSettingsViewController: UIViewController, UICollectionViewDelegate, UI
         self.collectionView.pinEdges()
         
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            collectionViewLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+            collectionViewLayout.estimatedItemSize = CGSize(width: 1, height: 1)
         }
         
         self.collectionView.reloadData()


### PR DESCRIPTION
Fix from the internet…
Note: I was able to see this on the iPhone 15 Pro Max simulator, slowly scrolling and staring at the bottom row as it became visible.