### PR TITLE
MAM-3615-crash-in-sidebarviewcontrollerdidmovetoparent

### DIFF
--- a/Mammoth/Screens/iPad/SidebarViewController.swift
+++ b/Mammoth/Screens/iPad/SidebarViewController.swift
@@ -141,7 +141,11 @@ class SidebarViewController: UIViewController, UICollectionViewDelegate, UIPenci
     override func didMove(toParent parent: UIViewController?) {
         super.didMove(toParent: parent)
         self.view.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addFillConstraints(with: self.view.superview!)
+        if let viewSuperview = self.view.superview {
+            self.view.addFillConstraints(with: viewSuperview)
+        } else {
+            log.warning("expected to be moved to a superview")
+        }
     }
         
     override func viewDidLoad() {


### PR DESCRIPTION
I was unable to reproduce the issue directly. Through code inspection, a nil superview will cause a crash, so I added a check for that.