### PR TITLE
MAM-3587-add-to-list-context-menu-sometimes-broken-on-macos

### DIFF
--- a/Mammoth/Models/UserCardModel.swift
+++ b/Mammoth/Models/UserCardModel.swift
@@ -91,7 +91,7 @@ class UserCardModel {
         self.joinedOn = account?.createdAt?.toDate()
     }
     
-    init(account: Account, instanceName: String? = nil, requestFollowStatusUpdate: FollowManager.NetworkUpdateType = .none) {
+    init(account: Account, instanceName: String? = nil, requestFollowStatusUpdate: FollowManager.NetworkUpdateType = .none, isFollowing: Bool = false) {
         self.id = account.id
         self.uniqueId = account.remoteFullOriginalAcct
         self.name = !account.displayName.isEmpty ? account.displayName : account.username
@@ -99,7 +99,7 @@ class UserCardModel {
         self.username = account.username
         self.imageURL = account.avatar
         self.description = account.note.stripHTML()
-        self.isFollowing = false
+        self.isFollowing = isFollowing
         self.emojis = account.emojis
         self.account = account
         

--- a/Mammoth/Screens/UserListScreen/UserListViewModel.swift
+++ b/Mammoth/Screens/UserListScreen/UserListViewModel.swift
@@ -61,7 +61,7 @@ class UserListViewModel {
                 return (users, pagination)
             case .following:
                 let (accounts, pagination) = try await AccountService.following(userId: user.id, instanceName: user.instanceName, range: range)
-                let users = accounts.map({ UserCardModel(account: $0, requestFollowStatusUpdate: .none) })
+                let users = accounts.map({ UserCardModel(account: $0, requestFollowStatusUpdate: .none, isFollowing: true) })
                 return (users, pagination)
             case .mutes:
 //                let (accounts, pagination) = try await AccountService.mutes(range: range)

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -221,7 +221,7 @@ extension PostCardProfilePic {
     
     func createContextMenu() -> UIMenu {
         guard let account = self.user?.account else { return UIMenu() }
-        let isFollowing = FollowManager.shared.followStatusForAccount(account) == .following
+        let isFollowing = FollowManager.shared.followStatusForAccount(account) == .following || (self.user?.isFollowing ?? false)
         
         if let user = self.user {
             if user.isSelf {


### PR DESCRIPTION
- use UserCardModel.isFollowing to track if the user is following this account (it doesn't appear to be used for any other purpose)
- when creating the list of UserCardModels for the 'Following" list, set this to true
- include checking this flag when creating the contextual menu