### PR TITLE
MAM-3617-post-actions-called-on-original-status-instead-of-local

### DIFF
--- a/Mammoth/Services/Backend/StatusService.swift
+++ b/Mammoth/Services/Backend/StatusService.swift
@@ -17,7 +17,7 @@ struct StatusService {
     }
     
     static func like(postCard: PostCardModel, withPolicy fetchPolicy: FetchPolicy = FetchPolicy.regular) async throws -> PostCardModel? {
-        switch postCard.data {
+        switch postCard.preSyncData ?? postCard.data {
         case .mastodon(let status):
             switch(fetchPolicy) {
             case .regular:
@@ -61,7 +61,7 @@ struct StatusService {
     }
     
     static func unlike(postCard: PostCardModel, withPolicy fetchPolicy: FetchPolicy = FetchPolicy.regular) async throws -> PostCardModel? {
-        switch postCard.data {
+        switch postCard.preSyncData ?? postCard.data {
         case .mastodon(let status):
             switch(fetchPolicy) {
             case .regular:


### PR DESCRIPTION
[MAM-3617 : Post actions called on original status instead of local status](https://linear.app/theblvd/issue/MAM-3617/post-actions-called-on-original-status-instead-of-local-status)

Some of the post actions were using the "synced" status instead of the status from the user's instance. When we sync a post, we query the original post and update the PostCardModel with it's original status. We store the local status under preSyncedData. Use that status for post actions instead.