### PR TITLE
MAM-3371-bd-misaligned-icontext-in-settings

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		BF34B1A62A0E9774002F3FED /* HashtagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF34B1A52A0E9774002F3FED /* HashtagManager.swift */; };
 		BF3841F32AD6F39A005C3995 /* EmailHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3841F22AD6F39A005C3995 /* EmailHandler.swift */; };
 		BF44B2D62B2D29F400442F61 /* PostLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF44B2D52B2D29F400442F61 /* PostLanguages.swift */; };
+		BF45FDEA2B34FF1800246C54 /* SettingsIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF45FDE92B34FF1800246C54 /* SettingsIcons.swift */; };
 		BF48B9322A8FE54F00DE6BFC /* ToastNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48B9312A8FE54F00DE6BFC /* ToastNotification.swift */; };
 		BF492DAE29F1E04C004100B8 /* QuotePostMutedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF492DAD29F1E04C004100B8 /* QuotePostMutedView.swift */; };
 		BF492DB029F21811004100B8 /* QuotePostMutedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BF492DAF29F21811004100B8 /* QuotePostMutedView.xib */; };
@@ -1419,6 +1420,7 @@
 		BF34B1A52A0E9774002F3FED /* HashtagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagManager.swift; sourceTree = "<group>"; };
 		BF3841F22AD6F39A005C3995 /* EmailHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailHandler.swift; sourceTree = "<group>"; };
 		BF44B2D52B2D29F400442F61 /* PostLanguages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLanguages.swift; sourceTree = "<group>"; };
+		BF45FDE92B34FF1800246C54 /* SettingsIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIcons.swift; sourceTree = "<group>"; };
 		BF48B9312A8FE54F00DE6BFC /* ToastNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastNotification.swift; sourceTree = "<group>"; };
 		BF492DAD29F1E04C004100B8 /* QuotePostMutedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotePostMutedView.swift; sourceTree = "<group>"; };
 		BF492DAF29F21811004100B8 /* QuotePostMutedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuotePostMutedView.xib; sourceTree = "<group>"; };
@@ -2784,6 +2786,7 @@
 				BF3841F22AD6F39A005C3995 /* EmailHandler.swift */,
 				14E08C692B20BF9C00EF5A55 /* DeviceHelpers.swift */,
 				1441736C2B2B1FDA0058AFCC /* SDImageTransformers.swift */,
+				BF45FDE92B34FF1800246C54 /* SettingsIcons.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3987,6 +3990,7 @@
 				533994A92914214A00560F83 /* AlertsSettingsViewController.swift in Sources */,
 				662B61102A4A1FB500CB331F /* FailableDecodable.swift in Sources */,
 				533994CE2914214A00560F83 /* SingleColumnViewController.swift in Sources */,
+				BF45FDEA2B34FF1800246C54 /* SettingsIcons.swift in Sources */,
 				53399A3A291526B900560F83 /* URLRequest.swift in Sources */,
 				BF193DC22AC4A03A00D0F6F7 /* ChannelCell.swift in Sources */,
 				C38B11142AAF1ED60077E053 /* ScrollUpIndicator.swift in Sources */,

--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -3932,7 +3932,6 @@ extension NewPostViewController: TranslationComposeViewControllerDelegate {
             let context = UIGraphicsGetCurrentContext()!
             let clipPath: CGPath = UIBezierPath(roundedRect: lineRect, cornerRadius: 2.0).cgPath
             context.addPath(clipPath)
-            context.setFillColor(UIColor.red.cgColor)
             context.closePath()
             context.setLineWidth(borderWidth)
             context.strokePath()

--- a/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
@@ -206,8 +206,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
             case 0:
                 let cell = UITableViewCell(style: .value1, reuseIdentifier: "UITableViewCell.value1")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f894}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
-
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f894}")
                 cell.textLabel?.text = self.firstSection[indexPath.row]
                 
                 if GlobalStruct.customTextSize == 0 {
@@ -247,7 +246,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
             case 0:
                 let cell = tableView.dequeueReusableCell(withIdentifier: "SelectionCell", for: indexPath) as! SelectionCell
                 cell.txtLabel.text = "Theme"
-                cell.imageV.image = FontAwesome.image(fromChar: "\u{f1fc}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageV.image = settingsFontAwesomeImage("\u{f1fc}")
                 switch GlobalStruct.overrideTheme {
                 case 1:
                     cell.txtLabel2.text = "Light"
@@ -258,7 +257,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
 
                 var gestureActions: [UIAction] = []
-                let op1 = UIAction(title: "System", image: FontAwesome.image(fromChar: "\u{f042}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal), identifier: nil) { action in
+                let op1 = UIAction(title: "System", image: settingsFontAwesomeImage("\u{f042}"), identifier: nil) { action in
                     GlobalStruct.overrideTheme = 0
                     UserDefaults.standard.set(0, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.systemDefault)
@@ -270,7 +269,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                     op1.state = .on
                 }
                 gestureActions.append(op1)
-                let op2 = UIAction(title: "Light", image: FontAwesome.image(fromChar: "\u{e0c9}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal), identifier: nil) { action in
+                let op2 = UIAction(title: "Light", image: settingsFontAwesomeImage("\u{e0c9}"), identifier: nil) { action in
                     GlobalStruct.overrideTheme = 1
                     UserDefaults.standard.set(1, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.light)
@@ -282,7 +281,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                     op2.state = .on
                 }
                 gestureActions.append(op2)
-                let op3 = UIAction(title: "Dark", image: FontAwesome.image(fromChar: "\u{f186}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal), identifier: nil) { action in
+                let op3 = UIAction(title: "Dark", image: settingsFontAwesomeImage("\u{f186}"), identifier: nil) { action in
                     GlobalStruct.overrideTheme = 2
                     UserDefaults.standard.set(2, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.dark)
@@ -307,7 +306,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 cell.txtLabel.text = "Names"
                 cell.accessibilityLabel = "Names"
                 
-                cell.imageV.image = FontAwesome.image(fromChar: "\u{f5b7}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageV.image = settingsFontAwesomeImage("\u{f5b7}")
                 if GlobalStruct.displayName == .full {
                     cell.txtLabel2.text = "Full"
                 } else if GlobalStruct.displayName == .usernameOnly {
@@ -319,7 +318,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
                 
                 var gestureActions: [UIAction] = []
-                let image1 = FontAwesome.image(fromChar: "\u{f47f}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                let image1 = settingsFontAwesomeImage("\u{f47f}")
                 let op1 = UIAction(title: "Full", image: image1, identifier: nil) { action in
                     
                     GlobalStruct.displayName = .full
@@ -332,7 +331,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
                 
                 gestureActions.append(op1)
-                let image2 = FontAwesome.image(fromChar: "\u{f007}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                let image2 = settingsFontAwesomeImage("\u{f007}")
                 let op2 = UIAction(title: "Username", image: image2, identifier: nil) { action in
                     
                     GlobalStruct.displayName = .usernameOnly
@@ -345,7 +344,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
                 
                 gestureActions.append(op2)
-                let image3 = FontAwesome.image(fromChar: "\u{40}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                let image3 = settingsFontAwesomeImage("\u{40}")
                 let op3 = UIAction(title: "Usertag", image: image3, identifier: nil) { action in
                     
                     GlobalStruct.displayName = .usertagOnly
@@ -358,7 +357,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
                 
                 gestureActions.append(op3)
-                let image4 = FontAwesome.image(fromChar: "\u{f656}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                let image4 = settingsFontAwesomeImage("\u{f656}")
                 let op4 = UIAction(title: "None", image: image4, identifier: nil) { action in
                     
                     GlobalStruct.displayName = .none
@@ -384,7 +383,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 cell.txtLabel.text = "Maximum lines"
                 cell.accessibilityLabel = "Maximum lines"
                 
-                cell.imageV.image = FontAwesome.image(fromChar: "\u{f7a4}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageV.image = settingsFontAwesomeImage("\u{f7a4}")
                 if GlobalStruct.maxLines == 0 {
                     cell.txtLabel2.text = "None"
                 } else {
@@ -417,7 +416,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
                 cell.textLabel?.numberOfLines = 0
                 cell.textLabel?.text = "Circle profile icons"
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f2bd}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f2bd}")
 
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "circleProfiles") as? Bool != nil {
@@ -445,7 +444,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
                 cell.textLabel?.numberOfLines = 0
                 cell.textLabel?.text = "Content warning overlays"
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f05e}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f05e}")
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "showCW") as? Bool != nil {
                     if UserDefaults.standard.value(forKey: "showCW") as? Bool == false {
@@ -471,7 +470,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
                 cell.textLabel?.numberOfLines = 0
                 cell.textLabel?.text = "Blur sensitive content"
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f071}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f071}")
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "blurSensitiveContent") as? Bool != nil {
                     if UserDefaults.standard.value(forKey: "blurSensitiveContent") as? Bool == false {
@@ -497,7 +496,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
                 cell.textLabel?.numberOfLines = 0
                 cell.textLabel?.text = "Auto-play videos & GIFs"
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f04b}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f04b}")
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "autoPlayVideos") as? Bool != nil {
                     if UserDefaults.standard.value(forKey: "autoPlayVideos") as? Bool == false {
@@ -523,7 +522,7 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
                 cell.textLabel?.text = "Translation language"
                 cell.imageView?.image = UIImage(systemName: "globe")
-                cell.imageView?.image = FontAwesome.image(fromChar: "\u{f0ac}").withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+                cell.imageView?.image = settingsFontAwesomeImage("\u{f0ac}")
                 cell.accessoryView = nil
                 cell.accessoryType = .disclosureIndicator
                 cell.backgroundColor = .custom.OVRLYSoftContrast

--- a/Mammoth/Screens/Settings/ComposerSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/ComposerSettingsViewController.swift
@@ -133,8 +133,6 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCell")
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCell2")
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCell3")
-        self.tableView.register(SelectionCell.self, forCellReuseIdentifier: "SelectionCell1")
-        self.tableView.register(SelectionCell.self, forCellReuseIdentifier: "SelectionCell2")
         self.tableView.register(SelectionCell.self, forCellReuseIdentifier: "SelectionCell3")
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCellS")
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCellU")
@@ -171,7 +169,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
             let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell2", for: indexPath)
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.text = "Require Image Descriptions"
-            cell.imageView?.image = UIImage(systemName: "text.below.photo")
+            cell.imageView?.image = settingsSystemImage("text.below.photo")
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "altText") as? Bool != nil {
                 if UserDefaults.standard.value(forKey: "altText") as? Bool == false {
@@ -201,7 +199,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                 let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell3", for: indexPath)
                 cell.textLabel?.numberOfLines = 0
                 cell.textLabel?.text = "Threader Mode"
-                cell.imageView?.image = UIImage(systemName: "lineweight")
+                cell.imageView?.image = settingsSystemImage("lineweight")
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "threaderMode") as? Bool != nil {
                     if UserDefaults.standard.value(forKey: "threaderMode") as? Bool == false {
@@ -232,22 +230,22 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                 cell.accessibilityLabel = "Thread Style"
                 if GlobalStruct.threaderStyle == 0 {
                     cell.txtLabel2.text = "None"
-                    cell.imageV.image = UIImage(systemName: "1.circle")
+                    cell.imageV.image = settingsSystemImage("1.circle")
                 } else if GlobalStruct.threaderStyle == 1 {
                     cell.txtLabel2.text = "..."
-                    cell.imageV.image = UIImage(systemName: "2.circle")
+                    cell.imageV.image = settingsSystemImage("2.circle")
                 } else if GlobalStruct.threaderStyle == 2 {
                     cell.txtLabel2.text = "(x/n)"
-                    cell.imageV.image = UIImage(systemName: "3.circle")
+                    cell.imageV.image = settingsSystemImage("3.circle")
                 } else if GlobalStruct.threaderStyle == 3 {
                     cell.txtLabel2.text = "🧵"
-                    cell.imageV.image = UIImage(systemName: "4.circle")
+                    cell.imageV.image = settingsSystemImage("4.circle")
                 } else {
                     cell.txtLabel2.text = "🪡"
-                    cell.imageV.image = UIImage(systemName: "5.circle")
+                    cell.imageV.image = settingsSystemImage("5.circle")
                 }
                 var gestureActions: [UIAction] = []
-                let op1 = UIAction(title: "None", image: UIImage(systemName: "1.circle"), identifier: nil) { action in
+                let op1 = UIAction(title: "None", image: settingsSystemImage("1.circle"), identifier: nil) { action in
                     GlobalStruct.threaderStyle = 0
                     UserDefaults.standard.set(GlobalStruct.threaderStyle, forKey: "threaderStyle")
                     self.tableView.reloadData()
@@ -256,7 +254,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                     op1.state = .on
                 }
                 gestureActions.append(op1)
-                let op2 = UIAction(title: "...", image: UIImage(systemName: "2.circle"), identifier: nil) { action in
+                let op2 = UIAction(title: "...", image: settingsSystemImage("2.circle"), identifier: nil) { action in
                     GlobalStruct.threaderStyle = 1
                     UserDefaults.standard.set(GlobalStruct.threaderStyle, forKey: "threaderStyle")
                     self.tableView.reloadData()
@@ -265,7 +263,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                     op2.state = .on
                 }
                 gestureActions.append(op2)
-                let op3 = UIAction(title: "(x/n)", image: UIImage(systemName: "3.circle"), identifier: nil) { action in
+                let op3 = UIAction(title: "(x/n)", image: settingsSystemImage("3.circle"), identifier: nil) { action in
                     GlobalStruct.threaderStyle = 2
                     UserDefaults.standard.set(GlobalStruct.threaderStyle, forKey: "threaderStyle")
                     self.tableView.reloadData()
@@ -274,7 +272,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                     op3.state = .on
                 }
                 gestureActions.append(op3)
-                let op4 = UIAction(title: "🧵", image: UIImage(systemName: "4.circle"), identifier: nil) { action in
+                let op4 = UIAction(title: "🧵", image: settingsSystemImage("4.circle"), identifier: nil) { action in
                     GlobalStruct.threaderStyle = 3
                     UserDefaults.standard.set(GlobalStruct.threaderStyle, forKey: "threaderStyle")
                     self.tableView.reloadData()
@@ -283,7 +281,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                     op4.state = .on
                 }
                 gestureActions.append(op4)
-                let op5 = UIAction(title: "🪡", image: UIImage(systemName: "5.circle"), identifier: nil) { action in
+                let op5 = UIAction(title: "🪡", image: settingsSystemImage("5.circle"), identifier: nil) { action in
                     GlobalStruct.threaderStyle = 4
                     UserDefaults.standard.set(GlobalStruct.threaderStyle, forKey: "threaderStyle")
                     self.tableView.reloadData()
@@ -293,7 +291,7 @@ class ComposerSettingsViewController: UIViewController, UITableViewDataSource, U
                 }
                 gestureActions.append(op5)
                 cell.bgButton.showsMenuAsPrimaryAction = true
-                cell.bgButton.menu = UIMenu(title: "", image: UIImage(systemName: "1.circle"), options: [.displayInline], children: gestureActions)
+                cell.bgButton.menu = UIMenu(title: "", image: settingsSystemImage("1.circle"), options: [.displayInline], children: gestureActions)
                 cell.accessoryView = .none
                 cell.selectionStyle = .none
                 let bgColorView = UIView()

--- a/Mammoth/Screens/Settings/ContactSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/ContactSettingsViewController.swift
@@ -151,7 +151,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell1", for: indexPath)
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell1")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: self.section0Images[indexPath.row])
+            cell.imageView?.image = settingsSystemImage(self.section0Images[indexPath.row])
             cell.textLabel?.text = self.firstSection[indexPath.row]
             cell.backgroundColor = .custom.OVRLYSoftContrast
             cell.accessoryType = .disclosureIndicator
@@ -163,7 +163,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell2", for: indexPath)
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell2")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: "safari")
+            cell.imageView?.image = settingsSystemImage("safari")
             cell.textLabel?.text = "Website"
             cell.backgroundColor = .custom.OVRLYSoftContrast
             if #available(iOS 15.0, *) {
@@ -174,7 +174,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell3", for: indexPath)
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell3")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: "hand.raised")
+            cell.imageView?.image = settingsSystemImage("hand.raised")
             cell.textLabel?.text = "Server Privacy Policy"
             cell.backgroundColor = .custom.OVRLYSoftContrast
             if #available(iOS 15.0, *) {
@@ -185,7 +185,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell4", for: indexPath)
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell4")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: "heart")
+            cell.imageView?.image = settingsSystemImage("heart")
             cell.textLabel?.text = "Review Prompt"
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "reviewPrompt") as? Bool != nil {
@@ -213,7 +213,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell5", for: indexPath)
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell5")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: "doc.text.magnifyingglass")
+                cell.imageView?.image = settingsSystemImage("doc.text.magnifyingglass")
                 cell.textLabel?.text = "Enable Debug Logging"
                 let switchView = UISwitch(frame: .zero)
                 
@@ -233,7 +233,7 @@ class ContactSettingsViewController: UIViewController, UITableViewDataSource, UI
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell6", for: indexPath)
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell6")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: "mail.and.text.magnifyingglass")
+                cell.imageView?.image = settingsSystemImage("mail.and.text.magnifyingglass")
                 cell.textLabel?.text = "Email Logs as Attachment"
                 cell.backgroundColor = .custom.OVRLYSoftContrast
                 if #available(iOS 15.0, *) {

--- a/Mammoth/Screens/Settings/HapticsSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/HapticsSettingsViewController.swift
@@ -166,7 +166,7 @@ class HapticsSettingsViewController: UIViewController, UITableViewDataSource, UI
             let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell0", for: indexPath)
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.text = "\(self.section0[indexPath.row])"
-            cell.imageView?.image = UIImage(systemName: "speaker.wave.3")
+            cell.imageView?.image = settingsSystemImage("speaker.wave.3")
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "sounds") as? Bool != nil {
                 if UserDefaults.standard.value(forKey: "sounds") as? Bool == false {
@@ -195,7 +195,7 @@ class HapticsSettingsViewController: UIViewController, UITableViewDataSource, UI
             let cell = tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.text = "\(self.section1[indexPath.row])"
-            cell.imageView?.image = UIImage(systemName: "waveform.path")
+            cell.imageView?.image = settingsSystemImage("waveform.path")
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "haptics") as? Bool != nil {
                 if UserDefaults.standard.value(forKey: "haptics") as? Bool == false {

--- a/Mammoth/Screens/Settings/NotificationSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/NotificationSettingsViewController.swift
@@ -220,7 +220,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell", for: indexPath)
             cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: self.section0Images[indexPath.row])
+            cell.imageView?.image = settingsSystemImage(self.section0Images[indexPath.row])
             cell.textLabel?.text = self.firstSection[indexPath.row]
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "notifs1") as? Bool != nil {
@@ -248,7 +248,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell2", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell2")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnMentions") as? Bool != nil {
@@ -288,7 +288,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell3", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell3")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnLikes") as? Bool != nil {
@@ -328,7 +328,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell4", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell4")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnReposts") as? Bool != nil {
@@ -368,7 +368,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell5", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell5")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnFollows") as? Bool != nil {
@@ -408,7 +408,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell6", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell6")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnPolls") as? Bool != nil {
@@ -448,7 +448,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
                 var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell7", for: indexPath)
                 cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCell7")
                 cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = UIImage(systemName: self.section1Images[indexPath.row])
+                cell.imageView?.image = settingsSystemImage(self.section1Images[indexPath.row])
                 cell.textLabel?.text = self.secondSection[indexPath.row]
                 let switchView = UISwitch(frame: .zero)
                 if UserDefaults.standard.value(forKey: "pnStatuses") as? Bool != nil {
@@ -489,7 +489,7 @@ class NotificationSettingsViewController: UIViewController, UITableViewDataSourc
             var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCellai", for: indexPath)
             cell = UITableViewCell(style: .default, reuseIdentifier: "settingsCellai")
             cell.textLabel?.numberOfLines = 0
-            cell.imageView?.image = UIImage(systemName: "bell.badge")
+            cell.imageView?.image = settingsSystemImage("bell.badge")
             cell.textLabel?.text = "Activity Badges"
             let switchView = UISwitch(frame: .zero)
             if UserDefaults.standard.value(forKey: "activityBadges") as? Bool != nil {

--- a/Mammoth/Screens/Settings/SettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SettingsViewController.swift
@@ -355,8 +355,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         case .normal:
             cell.textLabel?.textColor = .custom.highContrast
             cell.backgroundColor = .custom.OVRLYSoftContrast
-            cell.imageView?.image = FontAwesome.image(fromChar: item.imageName).withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
-            
+            cell.imageView?.image = settingsFontAwesomeImage(item.imageName)
         case .destructive:
             cell.textLabel?.textColor = .white
             cell.backgroundColor = .custom.destructive

--- a/Mammoth/Screens/Settings/SiriSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SiriSettingsViewController.swift
@@ -167,7 +167,7 @@ class SiriSettingsViewController: UIViewController, UITableViewDataSource, UITab
         var cell = tableView.dequeueReusableCell(withIdentifier: "settingsCell", for: indexPath)
         cell = UITableViewCell(style: .subtitle, reuseIdentifier: "settingsCell")
         cell.textLabel?.numberOfLines = 0
-        cell.imageView?.image = UIImage(systemName: self.section0Images[indexPath.row])
+        cell.imageView?.image = settingsSystemImage(self.section0Images[indexPath.row])
         cell.textLabel?.text = self.firstSection[indexPath.row]
         cell.backgroundColor = .custom.OVRLYSoftContrast
         

--- a/Mammoth/Utils/SettingsIcons.swift
+++ b/Mammoth/Utils/SettingsIcons.swift
@@ -1,0 +1,45 @@
+//
+//  SettingsIcons.swift
+//  Mammoth
+//
+//  Created by Riley on 12/21/23
+//  Copyright © 2023 The BLVD. All rights reserved.
+//
+
+import UIKit
+
+
+func settingsFontAwesomeImage(_ char: String) -> UIImage {
+    let image = FontAwesome.image(fromChar: char)
+    return settingsImage(image)
+}
+
+func settingsSystemImage(_ systemName: String) -> UIImage {
+    let image = UIImage(systemName: systemName)!
+    return settingsImage(image)
+}
+
+// Draw the image in a box as tall as the image, and in a standard width
+func settingsImage(_ glyph: UIImage) -> UIImage {
+    var settingsIconWidth = 28.0
+    if glyph.size.width > settingsIconWidth {
+        log.error("settings icon too wide")
+        settingsIconWidth = glyph.size.width
+    }
+    let imageSize = CGSize(width: settingsIconWidth, height: glyph.size.height)
+    let settingsImage = UIGraphicsImageRenderer(size: imageSize).image { _ in
+        
+        // Red background for testing
+        #if false
+        let context = UIGraphicsGetCurrentContext()!
+        let clipPath: CGPath = UIBezierPath(rect: CGRect(x: 0, y: 0, width: settingsIconWidth, height: glyph.size.height)).cgPath
+        context.addPath(clipPath)
+        context.setFillColor(UIColor.red.cgColor)
+        context.closePath()
+        context.fillPath()
+        #endif
+        
+        glyph.draw(at: CGPoint(x: (imageSize.width - glyph.size.width) / 2.0, y:0))
+    }
+    return settingsImage.withTintColor(.custom.mediumContrast, renderingMode: .alwaysOriginal)
+}

--- a/Mammoth/Views/Cells/SelectionCell.swift
+++ b/Mammoth/Views/Cells/SelectionCell.swift
@@ -56,7 +56,7 @@ class SelectionCell: UITableViewCell {
         
         contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-16-[bgButton]-16-|", options: [], metrics: nil, views: viewsDict))
         contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-6-[bgButton]-6-|", options: [], metrics: metricsDict, views: viewsDict))
-        contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-16-[imageV]-20-[txtLabel]-(>=16)-[txtLabel2]-16-|", options: [], metrics: nil, views: viewsDict))
+        contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-20-[imageV]-16-[txtLabel]-(>=16)-[txtLabel2]-16-|", options: [], metrics: nil, views: viewsDict))
         contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-8-[txtLabel]-8-|", options: [], metrics: metricsDict, views: viewsDict))
         contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-8-[txtLabel2]-8-|", options: [], metrics: metricsDict, views: viewsDict))
         


### PR DESCRIPTION
Create helper functions to create a fixed-size canvas, and draw the settings image in it, centered horizontally.

- create the helper functions for FontAwesome and SystemImage glyphs
- use the functions in the various settings ViewControllers
- remove some unused UITableView cell registrations
- adjust some constraints of the SelectionCell image