### PR TITLE
MAM-3607-onboarding-no-longer-remembers-that-i-already-follow-mammoth

### DIFF
--- a/Mammoth/Managers/AccountsManager/AcctData.swift
+++ b/Mammoth/Managers/AccountsManager/AcctData.swift
@@ -111,6 +111,7 @@ struct MastodonAcctData: AcctDataType {
     let defaultPostingLanguage: String?
     let emoticons: [Emoji]
     var forYou: ForYouAccount
+    @available(*, deprecated, message: "Using UserDefaults instead.")
     var wentThroughOnboarding: Bool // false for accounts coming from 1.x
     
     let client: Client
@@ -127,7 +128,7 @@ struct MastodonAcctData: AcctDataType {
         case wentThroughOnboarding
     }
     
-    init(account: Account, instanceData: InstanceData, client: Client, defaultPostVisibility: Visibility, defaultPostingLanguage: String?, emoticons: [Emoji], forYou: ForYouAccount, uniqueID: String? = nil, wentThroughOnboarding: Bool = false) {
+    init(account: Account, instanceData: InstanceData, client: Client, defaultPostVisibility: Visibility, defaultPostingLanguage: String?, emoticons: [Emoji], forYou: ForYouAccount, uniqueID: String? = nil) {
         self.uniqueID = uniqueID ?? UUID().uuidString
         self.account = account
         self.instanceData = instanceData
@@ -137,7 +138,7 @@ struct MastodonAcctData: AcctDataType {
         self.defaultPostingLanguage = defaultPostingLanguage
         self.emoticons = emoticons
         self.forYou = forYou
-        self.wentThroughOnboarding = wentThroughOnboarding
+        self.wentThroughOnboarding = false
     }
     
     init(from decoder: Decoder) throws {
@@ -163,6 +164,8 @@ struct MastodonAcctData: AcctDataType {
         } catch {
             forYou = ForYouAccount()
         }
+        // Although wentThroughOnboarding is deprecated, leave this here so we can
+        // read old values to upgrade account info as needed.
         do {
             wentThroughOnboarding = try container.decode(type(of: wentThroughOnboarding).self, forKey: .wentThroughOnboarding)
         } catch {
@@ -187,7 +190,7 @@ struct MastodonAcctData: AcctDataType {
         try container.encode(defaultPostingLanguage, forKey: .defaultPostLanguage)
         try container.encode(emoticons, forKey: .emoticons)
         try container.encode(forYou, forKey: .forYou)
-        try container.encode(wentThroughOnboarding, forKey: .wentThroughOnboarding)
+        // try container.encode(wentThroughOnboarding, forKey: .wentThroughOnboarding) Deprecated
     }
     
     func diskFolderName() -> String {

--- a/Mammoth/Managers/AccountsManager/AcctHandler.swift
+++ b/Mammoth/Managers/AccountsManager/AcctHandler.swift
@@ -75,7 +75,7 @@ class MastodonAcctHandler: AcctHandler {
                                         completion(error, nil)
                                     }
                                 } else {
-                                    let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
+                                    let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount())
                                     DispatchQueue.main.async {
                                         completion(nil, newAcct)
                                     }
@@ -124,7 +124,7 @@ class MastodonAcctHandler: AcctHandler {
                 }
             }
             if let account = statuses.value {
-                let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount(), wentThroughOnboarding: false)
+                let newAcct = MastodonAcctData(account: account, instanceData: instanceData, client: client, defaultPostVisibility: .public, defaultPostingLanguage: nil, emoticons: [], forYou: ForYouAccount())
                 DispatchQueue.main.async {
                     completion(nil, newAcct)
                 }
@@ -150,7 +150,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedDisplayName = try await AccountService.updateDisplayName(displayName: displayName)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedDisplayName, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedDisplayName, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -171,7 +171,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedAvatar = try await AccountService.updateAvatar(image: avatar, compressionQuality: 0.5)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedAvatar, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedAvatar, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -192,7 +192,7 @@ class MastodonAcctHandler: AcctHandler {
             }
             let accountWithUpdatedHeader = try await AccountService.updateHeader(image: header, compressionQuality: 0.5)
             if acctData.uniqueID == AccountsManager.shared.currentAccount?.uniqueID {
-                let updatedAcct = MastodonAcctData(account: accountWithUpdatedHeader, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+                let updatedAcct = MastodonAcctData(account: accountWithUpdatedHeader, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: mastodonAcct.forYou, uniqueID: acctData.uniqueID)
                 AccountsManager.shared.updateAccount(updatedAcct)
                 return updatedAcct
             } else {
@@ -235,7 +235,7 @@ class MastodonAcctHandler: AcctHandler {
             
             let postingLanguage: String? = updatedConstants?.defaultPostingLanguage
             
-            let updatedMastAcct = MastodonAcctData(account: updatedUser, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: postVisiblity, defaultPostingLanguage: postingLanguage, emoticons: updatedEmojis, forYou: mastodonAcct.forYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let updatedMastAcct = MastodonAcctData(account: updatedUser, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: postVisiblity, defaultPostingLanguage: postingLanguage, emoticons: updatedEmojis, forYou: mastodonAcct.forYou, uniqueID: mastodonAcct.uniqueID)
             AccountsManager.shared.updateAccount(updatedMastAcct)
             return updatedMastAcct
         } catch {
@@ -253,7 +253,7 @@ class MastodonAcctHandler: AcctHandler {
         do {
             let getForYou = try await TimelineService.forYouMe(remoteFullOriginalAcct: mastodonAcct.remoteFullOriginalAcct)
 
-            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: getForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: getForYou, uniqueID: mastodonAcct.uniqueID)
             AccountsManager.shared.updateAccount(updatedMastAcct)
             return updatedMastAcct
         } catch {
@@ -272,7 +272,7 @@ class MastodonAcctHandler: AcctHandler {
         do {
             let updatedForYou = try await TimelineService.updateForYouMe(remoteFullOriginalAcct: mastodonAcct.remoteFullOriginalAcct, forYouInfo: forYouInfo)
 
-            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: updatedForYou, uniqueID: mastodonAcct.uniqueID, wentThroughOnboarding: mastodonAcct.wentThroughOnboarding)
+            let updatedMastAcct = MastodonAcctData(account: mastodonAcct.account, instanceData: mastodonAcct.instanceData, client: mastodonAcct.client, defaultPostVisibility: mastodonAcct.defaultPostVisibility, defaultPostingLanguage: mastodonAcct.defaultPostingLanguage, emoticons: mastodonAcct.emoticons, forYou: updatedForYou, uniqueID: mastodonAcct.uniqueID)
             return updatedMastAcct
         } catch {
             log.error("problems updating user/server info: \(error)")

--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -174,7 +174,7 @@ private extension ProfileViewController {
         
         self.view.backgroundColor = .custom.background
 
-        let isPastOnboarding: Bool = (AccountsManager.shared.currentAccount as? MastodonAcctData)?.wentThroughOnboarding ?? true
+        let isPastOnboarding: Bool = !AccountsManager.shared.shouldShowOnboardingForCurrentAccount()
 
         if isPastOnboarding {
             self.settingsButton = ProfileViewSettingsButton({ [weak self] type, data in


### PR DESCRIPTION
- use UserDefaults to track accounts that have onboarded
- added a one-time migration of acctData.wentThroughOnboarding
- mark wentThroughOnboarding as deprecated
- remove uses of wentThroughOnboarding