### PR TITLE
MAM-3623-correctly-update-follow-status-on-profile-screen

### DIFF
--- a/Mammoth/Models/UserCardModel.swift
+++ b/Mammoth/Models/UserCardModel.swift
@@ -173,6 +173,7 @@ extension UserCardModel: Equatable {
         lhs.followersCount == rhs.followersCount &&
         lhs.isFollowing == rhs.isFollowing &&
         lhs.followStatus == rhs.followStatus &&
+        lhs.relationship == rhs.relationship &&
         lhs.fields == rhs.fields &&
         lhs.isBot == rhs.isBot &&
         lhs.isLocked == rhs.isLocked

--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -809,7 +809,7 @@ private extension ProfileViewModel {
         if let updatedfullAcct = notification.userInfo!["otherUserFullAcct"] as? String, let currentAccount = user?.account, updatedfullAcct == currentAccount.fullAcct {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                let userCard = UserCardModel(account: self.user!.account!)
+                let userCard = UserCardModel(account: currentAccount)
                 if userCard.followStatus != .inProgress {
                     self.user = userCard
                     // Update profile header

--- a/Mammoth/Services/Backend/MastodonKit/Models/Relationship.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Relationship.swift
@@ -8,7 +8,21 @@
 
 import Foundation
 
-public class Relationship: Codable {
+public class Relationship: Codable, Equatable {
+    public static func == (lhs: Relationship, rhs: Relationship) -> Bool {
+        return lhs.id == rhs.id &&
+        lhs.following == rhs.following &&
+        lhs.followedBy == rhs.followedBy &&
+        lhs.blocking == rhs.blocking &&
+        lhs.muting == rhs.muting &&
+        lhs.mutingNotifications == rhs.mutingNotifications &&
+        lhs.requested == rhs.requested &&
+        lhs.domainBlocking == rhs.domainBlocking &&
+        lhs.showingReblogs == rhs.showingReblogs &&
+        lhs.note == rhs.note &&
+        lhs.notifying == rhs.notifying
+    }
+    
     /// Target account id.
     public let id: String
     /// Whether the user is currently following the account.

--- a/Mammoth/Utils/PostActions.swift
+++ b/Mammoth/Utils/PostActions.swift
@@ -731,8 +731,8 @@ extension PostActions {
     }
     
     static func onProfilePress(target: UIViewController, postCard: PostCardModel) {
-        if let account = postCard.user?.account {
-            self.onProfilePress(target: target, account: account)
+        if let user = postCard.user {
+            self.onProfilePress(target: target, user: user)
         }
     }
     
@@ -740,7 +740,7 @@ extension PostActions {
         triggerHapticImpact(style: .light)
         
         let userCardModel = UserCardModel(account: account, requestFollowStatusUpdate: .whenUncertain)
-        let isSelf = account.fullAcct == AccountsManager.shared.currentUser()?.fullAcct
+        let isSelf = account.remoteFullOriginalAcct == AccountsManager.shared.currentUser()?.remoteFullOriginalAcct
         let profileVC = ProfileViewController(user: userCardModel, screenType: isSelf ? .own : .others)
         if profileVC.isBeingPresented {} else {
             target.navigationController?.pushViewController(profileVC, animated: true)
@@ -750,7 +750,7 @@ extension PostActions {
     static func onProfilePress(target: UIViewController, user: UserCardModel) {
         triggerHapticImpact(style: .light)
         
-        let isSelf = user.account?.fullAcct == AccountsManager.shared.currentUser()?.fullAcct
+        let isSelf = user.account?.remoteFullOriginalAcct == AccountsManager.shared.currentUser()?.remoteFullOriginalAcct
         let profileVC = ProfileViewController(user: user, screenType: isSelf ? .own : .others)
         if profileVC.isBeingPresented {} else {
             target.navigationController?.pushViewController(profileVC, animated: true)


### PR DESCRIPTION
[MAM-3623 : Correctly update follow status on Profile screen](https://linear.app/theblvd/issue/MAM-3623/correctly-update-follow-status-on-profile-screen)

When we don't have relationship information for a user we query that when opening a profile screen. The state of the follow button didn't update anymore to the correct state when the relationship object loaded.