### PR TITLE
MAM-3624-stop-videos-in-quote-posts-when-cell-is-not-visible

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -813,6 +813,10 @@ extension PostCardCell {
             self.video?.pause()
         }
         
+        if let postCard = self.postCard, postCard.hasQuotePost, let quotePostCard = postCard.quotePostData, let video = quotePostCard.videoPlayer {
+            video.pause()
+        }
+        
         self.header.stopTimeUpdates()
     }
     


### PR DESCRIPTION
[MAM-3624 : Stop videos in quote posts when cell is not visible](https://linear.app/theblvd/issue/MAM-3624/stop-videos-in-quote-posts-when-cell-is-not-visible)