### PR TITLE
MAM-3619-make-report-userpost-menu-items-red-add-confirmation-alert

### DIFF
--- a/Mammoth/Utils/PostActions.swift
+++ b/Mammoth/Utils/PostActions.swift
@@ -965,6 +965,26 @@ extension PostActions {
             }
         }
     }
+    
+    static func report(postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
+        guard let accountID = postCard.account?.id, case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        
+        let alert = UIAlertController(title: "Report this post?", message: "We'll notify your instance’s moderator.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Report post", style: .destructive , handler:{ (UIAlertAction) in
+            Task {
+                do {
+                    try await StatusService.report(accountID: accountID, status: status, withPolicy: .retryLocally)
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: Notification.Name(rawValue: "postReported"), object: nil)
+                    }
+                } catch let error {
+                    log.error("error reporting post - \(error)")
+                }
+            }
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        getTopMostViewController()?.present(alert, animated: true, completion: nil)
+    }
 }
 
 // MARK: - Legacy functions (deprecated)
@@ -1027,19 +1047,5 @@ extension PostActions {
             }
         }
         task.resume()
-    }
-    
-    static func report(postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard let accountID = postCard.account?.id, case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
-        Task {
-            do {
-                try await StatusService.report(accountID: accountID, status: status, withPolicy: .retryLocally)
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: Notification.Name(rawValue: "postReported"), object: nil)
-                }
-            } catch let error {
-                log.error("error reporting post - \(error)")
-            }
-        }
     }
 }

--- a/Mammoth/Utils/UserActions.swift
+++ b/Mammoth/Utils/UserActions.swift
@@ -252,16 +252,21 @@ struct UserActions {
     }
     
     static func report(account: Account) {
-        Task {
-            do {
-                try await AccountService.report(user: account, withPolicy: .retryLocally)
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: Notification.Name(rawValue: "userReported"), object: nil)
+        let alert = UIAlertController(title: "Report this user?", message: "We'll notify your instance’s moderator.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Report user", style: .destructive , handler:{ (UIAlertAction) in
+            Task {
+                do {
+                    try await AccountService.report(user: account, withPolicy: .retryLocally)
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: Notification.Name(rawValue: "userReported"), object: nil)
+                    }
+                } catch let error {
+                    log.error("error reporting user - \(error)")
                 }
-            } catch let error {
-                log.error("error reporting user - \(error)")
             }
-        }
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        getTopMostViewController()?.present(alert, animated: true, completion: nil)
     }
     
 }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -927,15 +927,29 @@ extension PostCardCell {
 
 // MARK: - Context menu creators
 extension PostCardCell {
-    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool, onPress: @escaping PostCardButtonCallback) -> UIAction {
+    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool, onPress: @escaping PostCardButtonCallback, attributes:  UIMenuElement.Attributes = []) -> UIAction {
+        
+        var color: UIColor = .black
+        if GlobalStruct.overrideTheme == 1 || self.traitCollection.userInterfaceStyle == .light {
+            color = .black
+        } else if GlobalStruct.overrideTheme == 2 || self.traitCollection.userInterfaceStyle == .dark  {
+            color = .white
+        }
+        
+        if attributes.contains(.destructive) {
+            color = UIColor.systemRed
+        }
+        
         let action = UIAction(title: title,
                               image: isActive
-                              ? buttonType.activeIcon(symbolConfig: postCardSymbolConfig)
-                              : buttonType.icon(symbolConfig: postCardSymbolConfig),
+                              ? buttonType.activeIcon(symbolConfig: postCardSymbolConfig)?.withTintColor(color).withRenderingMode(.alwaysTemplate)
+                              : buttonType.icon(symbolConfig: postCardSymbolConfig)?.withTintColor(color).withRenderingMode(.alwaysTemplate),
                                   identifier: nil) { _ in
             onPress(buttonType, isActive, nil)
         }
         action.accessibilityLabel = title
+        action.attributes = attributes
+  
         return action
     }
     
@@ -959,7 +973,7 @@ extension PostCardCell {
             createContextMenuAction("Translate post", .translate, isActive: false, onPress: onButtonPress),
             createContextMenuAction("View in browser", .viewInBrowser, isActive: false, onPress: onButtonPress),
             
-            ( !postCard.isOwn ? createContextMenuAction("Report post", .reportPost, isActive: false, onPress: onButtonPress) : nil),
+            ( !postCard.isOwn ? createContextMenuAction("Report post", .reportPost, isActive: false, onPress: onButtonPress, attributes: .destructive) : nil),
             
             createContextMenuAction("Share", .share, isActive: false, onPress: onButtonPress),
             
@@ -971,7 +985,8 @@ extension PostCardCell {
                     : createContextMenuAction("Pin post", .pinPost, isActive: false, onPress: onButtonPress)),
                 
                 createContextMenuAction("Edit post", .editPost, isActive: false, onPress: onButtonPress),
-                createContextMenuAction("Delete post", .deletePost, isActive: false, onPress: onButtonPress)])
+                createContextMenuAction("Delete post", .deletePost, isActive: false, onPress: onButtonPress, attributes: .destructive),
+             ])
              : nil)
         ].compactMap({$0})
         

--- a/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
@@ -251,11 +251,23 @@ private extension PostFooterButton {
 
 // MARK: - Context menu creators
 private extension PostFooterButton {
-    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool) -> UIAction {
+    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool, attributes:  UIMenuElement.Attributes = []) -> UIAction {
+        
+        var color: UIColor = .black
+        if GlobalStruct.overrideTheme == 1 || self.traitCollection.userInterfaceStyle == .light {
+            color = .black
+        } else if GlobalStruct.overrideTheme == 2 || self.traitCollection.userInterfaceStyle == .dark  {
+            color = .white
+        }
+        
+        if attributes.contains(.destructive) {
+            color = UIColor.systemRed
+        }
+        
         let action = UIAction(title: title,
                               image: isActive
-                              ? buttonType.activeIcon(symbolConfig: postCardSymbolConfig)?.withRenderingMode(.alwaysTemplate)
-                              : buttonType.icon(symbolConfig: postCardSymbolConfig)?.withRenderingMode(.alwaysTemplate),
+                              ? buttonType.activeIcon(symbolConfig: postCardSymbolConfig)?.withTintColor(color).withRenderingMode(.alwaysTemplate)
+                              : buttonType.icon(symbolConfig: postCardSymbolConfig)?.withTintColor(color).withRenderingMode(.alwaysTemplate),
                                   identifier: nil) { [weak self] _ in
             guard let self else { return }
             if buttonType == .repost {
@@ -264,6 +276,8 @@ private extension PostFooterButton {
                 self.onPress?(buttonType, isActive, nil)
             }
         }
+        
+        action.attributes = attributes
         action.accessibilityLabel = title
         return action
     }
@@ -281,15 +295,15 @@ private extension PostFooterButton {
         
         let translateItem = createContextMenuAction("Translate Post", .translate, isActive: false)
         let inBrowserItem = createContextMenuAction("View in Browser", .viewInBrowser, isActive: false)
-        let report = createContextMenuAction("Report Post", .reportPost, isActive: false)
+        let report = createContextMenuAction("Report Post", .reportPost, isActive: false, attributes: .destructive)
+        
         let shareItem = createContextMenuAction("Share", .share, isActive: false)
         let pinItem = postCard.isPinned
             ? createContextMenuAction("Unpin post", .pinPost, isActive: true)
             : createContextMenuAction("Pin post", .pinPost, isActive: false)
         
         let editPostItem = createContextMenuAction("Edit Post", .editPost, isActive: false)
-        let deletePostItem = createContextMenuAction("Delete Post", .deletePost, isActive: false)
-        deletePostItem.attributes = .destructive
+        let deletePostItem = createContextMenuAction("Delete Post", .deletePost, isActive: false, attributes: .destructive)
         
         let modifyMenu = UIMenu(title: "Modify Post", options: [], children: [pinItem, editPostItem, deletePostItem])
         

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -260,11 +260,11 @@ extension PostCardProfilePic {
                     createContextMenuAction("Mute Forever", .muteForever, isActive: true, data: nil)
                 ])),
                 
-                createContextMenuAction("Report @\(user.username)", .reportUser, isActive: true, data: nil),
+                createContextMenuAction("Report @\(user.username)", .reportUser, isActive: true, data: nil, attributes: .destructive),
                 
                 (user.isBlocked
                  ? createContextMenuAction("Unblock @\(user.username)", .unblock, isActive: true, data: nil)
-                 : createContextMenuAction("Block @\(user.username)", .block, isActive: true, data: nil)),
+                 : createContextMenuAction("Block @\(user.username)", .block, isActive: true, data: nil, attributes: .destructive)),
                                 
                 createContextMenuAction("Share Link", .share, isActive: true, data: nil),
             ].compactMap({$0})
@@ -276,7 +276,7 @@ extension PostCardProfilePic {
         return UIMenu()
     }
 
-    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool, data: PostCardButtonCallbackData?) -> UIAction {
+    private func createContextMenuAction(_ title: String, _ buttonType: PostCardButtonType, isActive: Bool, data: PostCardButtonCallbackData?, attributes:  UIMenuElement.Attributes = []) -> UIAction {
         var color: UIColor = .black
         if GlobalStruct.overrideTheme == 1 || self.traitCollection.userInterfaceStyle == .light {
             color = .black
@@ -284,13 +284,13 @@ extension PostCardProfilePic {
             color = .white
         }
         
-        if buttonType == .block {
+        if attributes.contains(.destructive) {
             color = UIColor.systemRed
         }
         
         let action = UIAction(title: title,
-                                  image: buttonType.icon(symbolConfig: postCardSymbolConfig)?.withTintColor(color),
-                                  identifier: nil, attributes: buttonType == .block ? .destructive : UIMenuElement.Attributes()) { _ in
+                                  image: buttonType.icon(symbolConfig: postCardSymbolConfig)?.withTintColor(color).withRenderingMode(.alwaysTemplate),
+                                  identifier: nil, attributes: attributes) { _ in
             self.onPress?(buttonType, isActive, data)
         }
         action.accessibilityLabel = title


### PR DESCRIPTION
[MAM-3619 : Make 'Report user/post' menu items red; add confirmation alert](https://linear.app/theblvd/issue/MAM-3619/make-report-userpost-menu-items-red-add-confirmation-alert)