### PR TITLE
MAM-3625-remove-follow-button-flickering-on-detail-screen

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -161,8 +161,6 @@ class PostCardHeader: UIView {
         self.userTagLabel.text = nil
         self.dateLabel.text = nil
         
-        self.followButton?.alpha = 0
-        
         self.stopTimeUpdates()
     }
     
@@ -278,9 +276,11 @@ extension PostCardHeader {
                 
             } else {
                 self.followButton?.isHidden = true
+                self.followButton?.alpha = 0
             }
         } else {
             self.followButton?.isHidden = true
+            self.followButton?.alpha = 0
         }
 
         if headerType == .quotePost, let user = postCard.user {


### PR DESCRIPTION
When a follow button is displayed in the post card header and you open the post' detail screen you see a flickering of the follow button. You shouldn't

[MAM-3625 : Remove Follow button flickering on detail screen](https://linear.app/theblvd/issue/MAM-3625/remove-follow-button-flickering-on-detail-screen)

https://github.com/TheBLVD/mammoth/assets/221925/5429b51a-b377-4deb-8c79-7815daa9bc7e

