### PR TITLE
MAM-3650-fix-the-activity-updates-tab

### DIFF
--- a/Mammoth/Models/ActivityCardModel.swift
+++ b/Mammoth/Models/ActivityCardModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct ActivityCardModel {
+class ActivityCardModel {
     let id: String  // Local ID (might not be unique across instances)
     let uniqueId: String // Unique ID across instances
     let cursorId: String // ID used for pagination

--- a/Mammoth/Services/Backend/TimelineService.swift
+++ b/Mammoth/Services/Backend/TimelineService.swift
@@ -125,7 +125,7 @@ struct TimelineService {
             case .follow:
                 return $0 != .follow
             case .update:
-                return $0 != .update
+                return $0 != .status
             default:
                 return [NotificationType.direct, NotificationType.mention].contains($0)
             }


### PR DESCRIPTION
Show `status` notification instead of `update` notifications on Updates tab on Activity screen

[MAM-3650 : Fix the Activity Updates tab](https://linear.app/theblvd/issue/MAM-3650/fix-the-activity-updates-tab)