### PR TITLE
MAM-3651-fix-bad-link-preview-text-clipping

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
@@ -146,13 +146,8 @@ private extension PostCardLinkPreview {
             imageView.trailingAnchor.constraint(equalTo: self.imageStack.trailingAnchor)
         ])
         
-        let urlLabelTrailing = urlLabel.trailingAnchor.constraint(equalTo: textStack.trailingAnchor)
-        urlLabelTrailing.priority = .defaultLow
-        urlLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        
-        let titleLabelTrailing = titleLabel.trailingAnchor.constraint(equalTo: textStack.trailingAnchor)
-        titleLabelTrailing.priority = .defaultLow
-        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        let urlLabelTrailing = urlLabel.trailingAnchor.constraint(equalTo: textStack.layoutMarginsGuide.trailingAnchor)
+        let titleLabelTrailing = titleLabel.trailingAnchor.constraint(equalTo: textStack.layoutMarginsGuide.trailingAnchor)
         
         NSLayoutConstraint.activate([
             // Force urlLabel to fill the parent width


### PR DESCRIPTION
[MAM-3651 : Fix bad Link preview text clipping](https://linear.app/theblvd/issue/MAM-3651/fix-bad-link-preview-text-clipping)

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-04 at 12 15 13](https://github.com/TheBLVD/mammoth/assets/221925/18e62edc-a76f-4d70-8cd6-27883558a572)
