### PR TITLE
MAM-3656-change-activity-label-from-updated-to-edited

### DIFF
--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -185,7 +185,7 @@ extension ActivityCardHeader {
         case .status:
             return "posted"
         case .update:
-            return "updated"
+            return "edited"
         case .direct:
             return "mentioned you"
         case .mention:


### PR DESCRIPTION
[MAM-3656 : Change Activity label from updated to edited](https://linear.app/theblvd/issue/MAM-3656/change-activity-label-from-updated-to-edited)