### PR TITLE
MAM-3659-rename-the-update-tab-into-posts-on-the-activity-tab

### DIFF
--- a/Mammoth/Screens/ActivityScreen/ActivityViewController.swift
+++ b/Mammoth/Screens/ActivityScreen/ActivityViewController.swift
@@ -104,7 +104,7 @@ class ActivityViewController : UIViewController {
             headerView.bottomAnchor.constraint(equalTo: blurEffectView.bottomAnchor)
         ])
         
-        self.headerView.carousel.content = ["All", "Likes", "Reposts", "Follows", "Updates"]
+        self.headerView.carousel.content = ["All", "Likes", "Reposts", "Follows", "Posts"]
     }
 }
 


### PR DESCRIPTION
[MAM-3659 : Rename the Update tab into Posts on the Activity tab](https://linear.app/theblvd/issue/MAM-3659/rename-the-update-tab-into-posts-on-the-activity-tab)