### PR TITLE
MAM-3658-remove-emoji-shortcodes-from-channel-creator-names-and

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		1450CE032ADD4FC300C91923 /* ListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1450CE022ADD4FC300C91923 /* ListService.swift */; };
 		146C6A432B34545B00A002D7 /* UnifiedBlurHash in Frameworks */ = {isa = PBXBuildFile; productRef = 146C6A422B34545B00A002D7 /* UnifiedBlurHash */; };
 		146C6A452B456EFB00A002D7 /* CarouselNavigationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C6A442B456EFB00A002D7 /* CarouselNavigationHeader.swift */; };
+		146C6A472B48113500A002D7 /* String+StripEmojis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C6A462B48113500A002D7 /* String+StripEmojis.swift */; };
 		14780F7B2AFBD6A700A7ECD9 /* RealtimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14780F7A2AFBD6A700A7ECD9 /* RealtimeManager.swift */; };
 		14780F812AFCEA7000A7ECD9 /* Reachability in Frameworks */ = {isa = PBXBuildFile; productRef = 14780F802AFCEA7000A7ECD9 /* Reachability */; };
 		149A682D2AD6A4E200E72A83 /* Mute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149A68282AD6A4E200E72A83 /* Mute.swift */; };
@@ -830,6 +831,7 @@
 		144DC7E92B18D29000F4EE98 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		1450CE022ADD4FC300C91923 /* ListService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListService.swift; sourceTree = "<group>"; };
 		146C6A442B456EFB00A002D7 /* CarouselNavigationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselNavigationHeader.swift; sourceTree = "<group>"; };
+		146C6A462B48113500A002D7 /* String+StripEmojis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripEmojis.swift"; sourceTree = "<group>"; };
 		14780F7A2AFBD6A700A7ECD9 /* RealtimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeManager.swift; sourceTree = "<group>"; };
 		149A68232AD6A1FE00E72A83 /* Mute-master */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "Mute-master"; path = "../Mute-master"; sourceTree = "<group>"; };
 		149A68282AD6A4E200E72A83 /* Mute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mute.swift; sourceTree = "<group>"; };
@@ -3058,6 +3060,7 @@
 				144DC6C82B14E26200F4EE98 /* UIColor+Gradient.swift */,
 				1441736E2B2C6C600058AFCC /* UIImageView+Caching.swift */,
 				BFBD97AB2B44ECDA00A0645B /* Bundle+decode.swift */,
+				146C6A462B48113500A002D7 /* String+StripEmojis.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3622,6 +3625,7 @@
 				53399A77291526B900560F83 /* Request.swift in Sources */,
 				53450E7A2936127C00D720EA /* DateFormatterTransform.swift in Sources */,
 				538E230229CC5815002675EB /* AccountsManager.swift in Sources */,
+				146C6A472B48113500A002D7 /* String+StripEmojis.swift in Sources */,
 				1441736D2B2B1FDA0058AFCC /* SDImageTransformers.swift in Sources */,
 				53B1585E293F66D20026E90B /* DecryptNotification.swift in Sources */,
 				5383F236298015B5005F1B20 /* SAConfettiView.swift in Sources */,

--- a/Mammoth/Utils/Extensions/String+StripEmojis.swift
+++ b/Mammoth/Utils/Extensions/String+StripEmojis.swift
@@ -1,0 +1,51 @@
+//
+//  String+StripEmojis.swift
+//  Mammoth
+//
+//  Created by Benoit Nolens on 05/01/2024
+//  Copyright © 2024 The BLVD. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func stripCustomEmojiShortcodes() -> String {
+        var strippedText = self
+        let regex = try! NSRegularExpression(pattern: ":[a-z_]+:", options: [])
+        let matches = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
+        
+        // Iterate through matches in reverse order to correctly adjust indices
+        for match in matches.reversed() {
+            let range = Range(match.range, in: self)!
+            let shortcode = self[range]
+            strippedText = strippedText.replacingOccurrences(of: String(shortcode), with: "")
+        }
+        
+        return strippedText.replaceDoubleSpaces()
+    }
+
+    func stripEmojis() -> String {
+        var strippedText = self
+        let regex = try! NSRegularExpression(pattern: "[\\p{Emoji}]", options: [])
+        let matches = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
+        
+        // Iterate through matches in reverse order to correctly adjust indices
+        for match in matches.reversed() {
+            let range = Range(match.range, in: self)!
+            strippedText = strippedText.replacingCharacters(in: range, with: "")
+        }
+        
+        return strippedText.replaceDoubleSpaces()
+    }
+    
+    func replaceDoubleSpaces() -> String {
+        let regex = try! NSRegularExpression(pattern: "\\s+", options: [])
+            let replacedText = regex.stringByReplacingMatches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count), withTemplate: " ")
+            return replacedText
+    }
+    
+    func stripLeadingTrailingSpaces() -> String {
+        let trimmedText = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedText
+    }
+}

--- a/Mammoth/Utils/Extensions/String+StripEmojis.swift
+++ b/Mammoth/Utils/Extensions/String+StripEmojis.swift
@@ -11,7 +11,7 @@ import Foundation
 extension String {
     func stripCustomEmojiShortcodes() -> String {
         var strippedText = self
-        let regex = try! NSRegularExpression(pattern: ":[a-z_]+:", options: [])
+        let regex = try! NSRegularExpression(pattern: ":[a-zA-Z0-9\\._]+:", options: [])
         let matches = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
         
         // Iterate through matches in reverse order to correctly adjust indices

--- a/Mammoth/Views/Cells/ChannelCell.swift
+++ b/Mammoth/Views/Cells/ChannelCell.swift
@@ -187,7 +187,11 @@ extension ChannelCell {
     func configure(channel: Channel, isSubscribed: Bool) {
         self.channel = channel
         self.titleLabel.attributedText = NewsFeedTypes.channel(channel).attributedTitle()
-        self.ownerButton.setTitle(channel.owner?.displayName ?? "", for: .normal)
+        self.ownerButton.setTitle(channel.owner?
+            .displayName
+            .stripCustomEmojiShortcodes()
+            .stripEmojis()
+            .stripLeadingTrailingSpaces() ?? "", for: .normal)
         self.descriptionLabel.text = channel.description
         self.channelPic.configure(channel: channel)
                 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
@@ -78,18 +78,16 @@ private extension PostCardHeaderExtension {
 // MARK: - Configuration
 extension PostCardHeaderExtension {
     func configure(postCard: PostCardModel) {
-        guard case .mastodon(let status) = postCard.data else { return }
+        guard case .mastodon(_) = postCard.data else { return }
         
         self.postCard = postCard
         
         if postCard.isReblogged {
-            if let name = postCard.richRebloggerUsername {
-                let string = NSMutableAttributedString(attributedString: formatRichText(string: name, label: self.titleLabel, emojis: status.account?.emojis))
-                string.append(NSMutableAttributedString(string: " reposted"))
-                self.titleLabel.attributedText = string
-            } else {
-                self.titleLabel.text = postCard.rebloggerUsername + " reposted"
-            }
+            self.titleLabel.text = postCard
+                .rebloggerUsername
+                .stripCustomEmojiShortcodes()
+                .stripEmojis()
+                .stripLeadingTrailingSpaces() + " reposted"
         }
         
         if postCard.isHashtagged {


### PR DESCRIPTION
[MAM-3658 : Remove emoji shortcodes from channel creator names and reblogger names?](https://linear.app/theblvd/issue/MAM-3658/remove-emoji-shortcodes-from-channel-creator-names-and-reblogger-names)

Stripping emojis from Smart List owner display names and from Reblog display names

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-05 at 11 49 43](https://github.com/TheBLVD/mammoth/assets/221925/a9081ef1-8506-4a31-a270-277ef8dffd25)

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-05 at 11 47 51](https://github.com/TheBLVD/mammoth/assets/221925/0973e519-a8fe-4436-ae89-81e76aa5a67c)
