### PR TITLE
Mam 3669 not using remote instances for post fetching

### DIFF
--- a/Mammoth/Models/UserCardModel.swift
+++ b/Mammoth/Models/UserCardModel.swift
@@ -22,7 +22,7 @@ class UserCardModel {
     let emojis: [Emoji]?
     let account: Account?
     
-    var instanceName: String?
+    var instanceName: String? // if set, it referrs to the instance for the id
     
     let isLocked: Bool
     let isBot: Bool

--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -78,8 +78,19 @@ class ProfileViewController: UIViewController, UIScrollViewDelegate, UITableView
         }
     }
     
-    convenience init(fullAcct: String, serverName: String = AccountsManager.shared.currentAccountClient.baseHost) {
-        self.init(viewModel: ProfileViewModel(fullAcct: fullAcct, serverName: serverName))
+    convenience init(fullAcct: String, serverName: String? = nil) {
+        // If no server is specified, use the server name from fullAcct
+        var instanceName = serverName
+        if instanceName == nil {
+            if let index = fullAcct.range(of: "@", options: .backwards)?.upperBound {
+                instanceName = String(fullAcct.suffix(from: index))
+            }
+        }
+        // If there's still no valid server name, use the user's instance
+        if instanceName == nil {
+            instanceName = AccountsManager.shared.currentAccountClient.baseHost
+        }
+        self.init(viewModel: ProfileViewModel(fullAcct: fullAcct, serverName: instanceName!))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -54,8 +54,12 @@ class ProfileViewController: UIViewController, UIScrollViewDelegate, UITableView
 
     private var viewModel: ProfileViewModel
 
-    required init(user: UserCardModel? = nil, screenType: ProfileViewModel.ProfileScreenType = .own) {
-        self.viewModel = ProfileViewModel(.posts, user: user, screenType: screenType)
+    required init(user: UserCardModel? = nil, screenType: ProfileViewModel.ProfileScreenType = .own, viewModel: ProfileViewModel? = nil) {
+        if let viewModel {
+            self.viewModel = viewModel
+        } else {
+            self.viewModel = ProfileViewModel(.posts, user: user, screenType: screenType)
+        }
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self
 
@@ -75,14 +79,7 @@ class ProfileViewController: UIViewController, UIScrollViewDelegate, UITableView
     }
     
     convenience init(fullAcct: String, serverName: String = AccountsManager.shared.currentAccountClient.baseHost) {
-        self.init()
-        self.viewModel = ProfileViewModel(fullAcct: fullAcct, serverName: serverName)
-        self.viewModel.delegate = self
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(self.reloadAll),
-                                               name: NSNotification.Name(rawValue: "reloadAll"),
-                                               object: nil)
+        self.init(viewModel: ProfileViewModel(fullAcct: fullAcct, serverName: serverName))
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
- use the profile's instance to get their posts
- use the smart-list owner's instance to get their profile

NOTE: this is on top of MAM-3678