### PR TITLE
MAM-3669-v2-not-using-remote-instances-for-post-fetching

### DIFF
--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -94,7 +94,7 @@ final class ProfileViewModel {
             guard let self else { return }
             
             // If server is Threads.net, use the user's local instance
-            let serverName = serverName == "www.threads.net"
+            let serverName = (serverName == "www.threads.net")
                 ? AccountsManager.shared.currentAccountClient.baseHost
                 : serverName
             
@@ -379,8 +379,8 @@ extension ProfileViewModel {
                 guard var user = user else { return nil }
                 await MainActor.run {self.state = .loading }
                 
-                // Fetch the user on its original instance
-                let instanceName = user.instanceName ?? AccountsManager.shared.currentAccountClient.baseHost
+                // Fetch the profile on its original instance
+                let instanceName = user.instanceName ?? user.account?.server ?? AccountsManager.shared.currentAccountClient.baseHost
                 if let account = await AccountService.lookup(user.uniqueId, serverName: instanceName), !forceLocal {
                     return await MainActor.run { [weak self] in
                         guard let self else { return nil }

--- a/Mammoth/Views/Cells/ChannelCell.swift
+++ b/Mammoth/Views/Cells/ChannelCell.swift
@@ -16,7 +16,8 @@ protocol ChannelCellDelegate: AnyObject {
 extension UIViewController: ChannelCellDelegate {
     func didTapChannelOwner(channel: Channel) {
         if let acct = channel.owner?.acct {
-            let vc = ProfileViewController(fullAcct: acct)
+            let serverName = channel.owner?.domain ?? AccountsManager.shared.currentAccountClient.baseHost
+            let vc = ProfileViewController(fullAcct: acct, serverName: serverName)
             if vc.isBeingPresented {} else {
                 self.navigationController?.pushViewController(vc, animated: true)
             }


### PR DESCRIPTION
- use the profile's instance in ProfileViewModel.reloadUser()
- use the Smart List owner's domain/instance when possible