### PR TITLE
MAM-3697-text-in-profiles-on-build-372-not-displayed-properly

### DIFF
--- a/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
@@ -315,6 +315,8 @@ extension ProfileHeader {
         self.user = user
         self.screenType = screenType
         
+        self.onThemeChange()
+        
         self.profilePic.configure(user: user)
         
         if let content = user.metaName {
@@ -443,8 +445,6 @@ extension ProfileHeader {
             
             NSLayoutConstraint.activate(extraInfoConstraints!)
         }
-        
-        self.onThemeChange()
     }
     
     func optimisticUpdate(image: UIImage) {
@@ -514,6 +514,8 @@ extension ProfileHeader {
         if screenType == .own {
             self.actionButton.menu = self.createContextMenu()
         }
+        
+        self.setNeedsDisplay()
     }
     
     @objc func followTapped() {


### PR DESCRIPTION
[MAM-3697 : Text in Profiles on Build 372 not displayed properly](https://linear.app/theblvd/issue/MAM-3697/text-in-profiles-on-build-372-not-displayed-properly)