### PR TITLE
MAM-3708-retry-loading-feed-if-the-user-returns-a-500

### DIFF
--- a/Mammoth/Services/Backend/MastodonKit/Client.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Client.swift
@@ -78,7 +78,7 @@ public class Client: NSObject, ClientType, URLSessionTaskDelegate {
                     let statusCode = (response as? HTTPURLResponse)?.statusCode
                     log.error("error status code: \(statusCode ?? 0)")
                     let mastodonError = try? MastodonError.decode(data: data)
-                    let error: ClientError = mastodonError.map { .mastodonError($0.description) } ?? .genericError
+                    let error: ClientError = mastodonError.map { .mastodonError($0.description) } ?? (statusCode != nil ? .networkError(statusCode!) : .genericError)
                     completion(.failure(error))
                     NetworkMonitor.shared.logNetworkCall(response: response, isMothClient: self.isMothClient)
                     return

--- a/Mammoth/Services/Backend/MastodonKit/ClientError.swift
+++ b/Mammoth/Services/Backend/MastodonKit/ClientError.swift
@@ -17,6 +17,8 @@ public enum ClientError: Error {
     case invalidModel
     /// Generic error.
     case genericError
+    ///  Network error.
+    case networkError(_ statusCode: Int)
     /// The Mastodon service returned an error.
     case mastodonError(_ message: String)
 }


### PR DESCRIPTION
- add a ClientError.networkError (with a status code) for network errors
- throw this error when necessary
- retry timeline requests for status code 206 and 500