### PR TITLE
MAM-3680-setting-app-icon-doesnt-work-on-macos

### DIFF
--- a/Mammoth/Screens/Settings/SettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SettingsViewController.swift
@@ -103,12 +103,12 @@ class SettingsViewController: UIViewController {
                 ]),
                 Section(items: [
                     .postAppearance,
-                    .appIcon,
+                    UIApplication.shared.supportsAlternateIcons ? .appIcon : nil,
                     .composer,
                     .pushNotifications,
                     .soundsAndHaptics,
                     .siriShortcuts
-                ]),
+                ].compactMap{$0}),
                 Section(items: [
                     .getInTouch,
                     .subscriptions,
@@ -131,12 +131,12 @@ class SettingsViewController: UIViewController {
                 ]),
                 Section(items: [
                     .postAppearance,
-                    .appIcon,
+                    UIApplication.shared.supportsAlternateIcons ? .appIcon : nil,
                     .composer,
                     .pushNotifications,
                     .soundsAndHaptics,
                     .siriShortcuts
-                ]),
+                ].compactMap{$0}),
                 Section(items: [
                     .getInTouch,
                     .openSourceCredits,

--- a/Mammoth/Views/Cells/UpgradeCell.swift
+++ b/Mammoth/Views/Cells/UpgradeCell.swift
@@ -428,7 +428,11 @@ private extension UpgradeRootView {
         expandedStack.addArrangedSubview(productOptionsStack)
         
         optionsListStack.addArrangedSubview(createOptionLabel("early access to new features"))
-        optionsListStack.addArrangedSubview(createOptionLabel("supporter only app icons"))
+        var appIconBenefit = "supporter only app icons"
+        if !UIApplication.shared.supportsAlternateIcons {
+            appIconBenefit += " (iOS)"
+        }
+        optionsListStack.addArrangedSubview(createOptionLabel(appIconBenefit))
         optionsListStack.addArrangedSubview(createOptionLabel("support an open and free web"))
         optionsListStack.addArrangedSubview(createOptionLabel("vote on new features"))
         


### PR DESCRIPTION
MOVED TO DRAFT UNTIL WE AGREE ON WHAT TO DO HERE

- change description of setting app icon if not supported by the platform
- hide the app icon setting row if not supported by the platform