### PR TITLE
MAM-3661-user-infoavatar-wrong-in-for-you-for-a-few-seconds-in-feed

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -167,10 +167,13 @@ extension PostCardProfilePic {
         self.user = user
         
         if let profileStr = user.imageURL, let profileURL = URL(string: profileStr) {
+            let userForImage = user
             self.profileImageView.ma_setImage(with: profileURL,
                                               cachedImage: self.user?.decodedProfilePic,
                                               imageTransformer: PostCardProfilePic.transformer) { image in
-                user.decodedProfilePic = image
+                if userForImage == self.user {
+                    user.decodedProfilePic = image
+                }
             }
         }
         


### PR DESCRIPTION
Only set the avatar image if self.user hasn't changed between the request and return of the image.