### PR TITLE
MAM-3705-make-double-tap-home-more-bullet-proof

### DIFF
--- a/Mammoth/Utils/Extensions/UITableView+SafeScrollToRow.swift
+++ b/Mammoth/Utils/Extensions/UITableView+SafeScrollToRow.swift
@@ -15,6 +15,7 @@ extension UITableView {
            indexPath.row < self.numberOfRows(inSection: indexPath.section) {
             self.scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
         } else {
+            self.setContentOffset(.zero, animated: true)
             log.error("Tried to scroll to a non-existant indexPath: \(indexPath)")
         }
     }

--- a/Mammoth/Utils/Protocols/Jumpable.swift
+++ b/Mammoth/Utils/Protocols/Jumpable.swift
@@ -47,13 +47,13 @@ extension Jumpable {
             if currentViewController.responds(to: jumpToSelector) {
                 let success = UIApplication.shared.sendAction(jumpToSelector, to: currentViewController, from: self, for: nil)
                 if !success {
-                    log.warning("no handler for jumpToNewest:")
+                    log.error("no handler for jumpToNewest:")
                 }
             } else {
-                log.warning("currentVC does not respond to jumpToSelector")
+                log.error("currentVC does not respond to jumpToSelector")
             }
         } else {
-            log.warning("[jumpToSelector] cannot find VC at index")
+            log.error("[jumpToSelector] cannot find VC at index")
         }
     }
 

--- a/Mammoth/Utils/Protocols/Jumpable.swift
+++ b/Mammoth/Utils/Protocols/Jumpable.swift
@@ -49,7 +49,11 @@ extension Jumpable {
                 if !success {
                     log.warning("no handler for jumpToNewest:")
                 }
+            } else {
+                log.warning("currentVC does not respond to jumpToSelector")
             }
+        } else {
+            log.warning("[jumpToSelector] cannot find VC at index")
         }
     }
 


### PR DESCRIPTION
- Tentative fix for scroll-to-top when no indexPath is found
- More error logging

[MAM-3705 : Make double-tap Home more bullet proof](https://linear.app/theblvd/issue/MAM-3705/make-double-tap-home-more-bullet-proof)