### PR TITLE
MAM-3677-videos-in-mammoth-cant-be-scrubbed

### DIFF
--- a/Mammoth/Views/CustomVideoPlayer.swift
+++ b/Mammoth/Views/CustomVideoPlayer.swift
@@ -25,7 +25,7 @@ class CustomVideoPlayer: AVPlayerViewController, UIContextMenuInteractionDelegat
         let interaction0 = UIContextMenuInteraction(delegate: self)
         self.view.addInteraction(interaction0)
         self.videoGravity = .resizeAspect
-        self.requiresLinearPlayback = true
+        self.requiresLinearPlayback = false
         self.showsPlaybackControls = false
         
         self.delegate = self


### PR DESCRIPTION
Videos can now be scrubbed in fullscreen custom video player

[MAM-3677 : Videos in Mammoth can't be scrubbed](https://linear.app/theblvd/issue/MAM-3677/videos-in-mammoth-cant-be-scrubbed)