### PR TITLE
MAM-3699-custom-emojis-in-info-and-links-not-displaying

### DIFF
--- a/Mammoth/Models/UserCardModel.swift
+++ b/Mammoth/Models/UserCardModel.swift
@@ -110,7 +110,7 @@ class UserCardModel {
         self.followersCount = max(account?.followersCount ?? 0, 0).formatUsingAbbrevation()
         
         self.fields = account?.fields
-        self.fields?.forEach({$0.configureMetaValue(with: emojisDic)})
+        self.fields?.forEach({$0.configureMetaContent(with: emojisDic)})
         self.joinedOn = account?.createdAt?.toDate()
     }
     
@@ -159,7 +159,7 @@ class UserCardModel {
         self.followersCount = max(account.followersCount, 0).formatUsingAbbrevation()
         
         self.fields = account.fields
-        self.fields?.forEach({$0.configureMetaValue(with: emojisDic)})
+        self.fields?.forEach({$0.configureMetaContent(with: emojisDic)})
         self.joinedOn = account.createdAt?.toDate()
     }
     

--- a/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
@@ -672,12 +672,11 @@ final class ProfileField: UIStackView, MetaLabelDelegate {
         return stackView
     }()
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 1, weight: .regular)
-        label.textColor = .custom.feintContrast
+    private let titleLabel: MetaLabel = {
+        let label = MetaLabel()
         label.textAlignment = .left
         label.numberOfLines = 1
+        label.textContainer.lineFragmentPadding = 0
         return label
     }()
     
@@ -685,8 +684,6 @@ final class ProfileField: UIStackView, MetaLabelDelegate {
         
     private let descriptionLabel: MetaLabel = {
         let label = MetaLabel()
-        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 1, weight: .regular)
-        label.textColor = .custom.mediumContrast
         label.textAlignment = .left
         label.numberOfLines = 0
         label.isOpaque = true
@@ -703,7 +700,9 @@ final class ProfileField: UIStackView, MetaLabelDelegate {
         super.init(frame: .zero)
         setupUI()
         
-        titleLabel.text = field.name
+        if let name = field.metaName {
+            titleLabel.configure(content: name)
+        }
         
         if let verifiedAt = field.verifiedAt, !verifiedAt.isEmpty {
             valueStack.insertArrangedSubview(verifiedImage, at: 0)
@@ -765,7 +764,15 @@ final class ProfileField: UIStackView, MetaLabelDelegate {
     }
     
     func onThemeChange() {
-        self.titleLabel.textColor = .custom.feintContrast
+        self.titleLabel.textAttributes = [
+            .font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 1, weight: .regular),
+            .foregroundColor: UIColor.custom.feintContrast,
+        ]
+        
+        self.titleLabel.linkAttributes = [
+            .font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 1, weight: .regular),
+            .foregroundColor: UIColor.custom.feintContrast,
+        ]
         
         self.descriptionLabel.textAttributes = [
             .font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize + 1, weight: .regular),

--- a/Mammoth/Services/Backend/MastodonKit/Models/HashType.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/HashType.swift
@@ -13,6 +13,7 @@ import MastodonMeta
 public class HashType: Codable {
     
     public let name: String
+    public var metaName: MastodonMetaContent?
     public let value: String
     public var metaValue: MastodonMetaContent?
     public let verifiedAt: String?
@@ -25,11 +26,17 @@ public class HashType: Codable {
 }
 
 extension HashType {
-    public func configureMetaValue(with emojis: MastodonContent.Emojis) {
+    public func configureMetaContent(with emojis: MastodonContent.Emojis) {
         do {
             self.metaValue = try MastodonMetaContent.convert(document: MastodonContent(content: self.value, emojis: emojis))
         } catch {
             self.metaValue = MastodonMetaContent.convert(text: MastodonContent(content: self.value, emojis: emojis))
+        }
+        
+        do {
+            self.metaName = try MastodonMetaContent.convert(document: MastodonContent(content: self.name, emojis: emojis))
+        } catch {
+            self.metaName = MastodonMetaContent.convert(text: MastodonContent(content: self.name, emojis: emojis))
         }
     }
 }


### PR DESCRIPTION
Support custom emojis in info&link titles

[MAM-3699 : Custom Emojis in Info and Links not displaying](https://linear.app/theblvd/issue/MAM-3699/custom-emojis-in-info-and-links-not-displaying)