### PR TITLE
Add missing 'bookmarked' property to the CodingKeys of Status

### DIFF
--- a/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
@@ -103,6 +103,7 @@ public class Status: Codable, Hashable {
         case favouritesCount = "favourites_count"
         case reblogged
         case favourited
+        case bookmarked
         case sensitive
         case spoilerText = "spoiler_text"
         case visibility


### PR DESCRIPTION
The `bookmarked` property was missing from CodingKeys, which means that no remotely bookmarked statuses would ever have their bookmarked property set true, preventing them from being correctly displayed, or capable of being removed within the app.