### PR TITLE
MAM-3451-post-removed-showing-for-multiple-people-in-feeds

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -78,7 +78,7 @@ class NewsFeedViewController: UIViewController, UIScrollViewDelegate, UITableVie
         if let isActive = self.delegate?.isActiveFeed(self.type){
             return isActive
         }
-        return false
+        return true
     }
     
     convenience init(type: NewsFeedTypes) {

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
@@ -649,7 +649,11 @@ extension NewsFeedViewModel {
                             let user = postCard.user,
                             let instanceName = user.instanceName {
                             // Do a webfinger lookup and only delete post if the account is federated
-                            if let webfinger = await AccountService.webfinger(user: user, serverName: instanceName), !webfinger.isEmpty {
+                            let webfinger = await AccountService.webfinger(user: user, serverName: instanceName)
+                            // Webfinger returns nil if account is deleted and returns a non-empty string if account is federated.
+                            // In both cases, mark the post as deleted.
+                            // Webfinger returns an empty string when account is not federated. In that case, don't mark the post as deleted.
+                            if webfinger == nil || !webfinger!.isEmpty {
                                 let deletedPostCard = postCard
                                 deletedPostCard.isDeleted = true
                                 NotificationCenter.default.post(name: PostActions.didUpdatePostCardNotification, object: nil, userInfo: ["postCard": deletedPostCard])

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -201,7 +201,7 @@ final class PostCardCell: UITableViewCell {
         button.contentVerticalAlignment = .center
         button.contentHorizontalAlignment = .center
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.isUserInteractionEnabled = true
+        button.isUserInteractionEnabled = false
 
         button.isOpaque = true
         return button
@@ -482,7 +482,7 @@ private extension PostCardCell {
         deletedWarningButton.isHidden = true
         deletedWarningButton.setTitle("Post removed", for: .normal)
         deletedWarningConstraints = [
-            deletedWarningButton.topAnchor.constraint(equalTo: contentStackView.topAnchor, constant: -1),
+            deletedWarningButton.topAnchor.constraint(equalTo: wrapperStackView.topAnchor, constant: -1),
             deletedWarningButton.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: -8),
             deletedWarningButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor, constant: -1),
             deletedWarningButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: 1),

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -192,6 +192,8 @@ extension PostCardProfilePic {
     }
     
     func onThemeChange() {
+        self.profileImageView.backgroundColor = .custom.OVRLYSoftContrast
+        
         if let user = self.user {
             self.configure(user: user)
         }


### PR DESCRIPTION
When fetching a post returns a 404 (in feed sync logic), do a webfinger lookup and only delete the post if the account is federated.

[MAM-3451 : “Post removed” showing for multiple people in Feeds](https://linear.app/theblvd/issue/MAM-3451/post-removed-showing-for-multiple-people-in-feeds)