### PR TITLE
MAM-3728-wrong-avatarimages-displayed-while-feed-loads

### DIFF
--- a/Mammoth/Utils/Extensions/UIImageView+Caching.swift
+++ b/Mammoth/Utils/Extensions/UIImageView+Caching.swift
@@ -20,8 +20,12 @@ extension UIImageView {
                 placeholderImage: placeholder,
                 context: [.imageTransformer: imageTransformer],
                 progress: nil
-            ) { image, _, _, _ in
-                completed(image)
+            ) { image, error, _, _ in
+                if let error {
+                    // Likely the image request was cancelled
+                } else {
+                    completed(image)
+                }
             }
         }
     }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -200,6 +200,7 @@ final class ActivityCardCell: UITableViewCell {
             postCard.preloadQuotePost()
         }
         
+        self.profilePic.willDisplay()
         self.header.startTimeUpdates()
     }
     

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -806,6 +806,7 @@ extension PostCardCell {
         }
         
         self.header.startTimeUpdates()
+        self.profilePic.willDisplay()
     }
     
     // the cell will end being displayed in the tableview

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -212,11 +212,11 @@ extension PostCardProfilePic {
         if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
             if self.profileImageView.sd_currentImageURL != profileURL {
                 self.profileImageView.sd_cancelCurrentImageLoad()
+                
+                self.profileImageView.ma_setImage(with: profileURL,
+                                                  cachedImage: self.user?.decodedProfilePic,
+                                                  imageTransformer: PostCardProfilePic.transformer) { image in }
             }
-            
-            self.profileImageView.ma_setImage(with: profileURL,
-                                              cachedImage: self.user?.decodedProfilePic,
-                                              imageTransformer: PostCardProfilePic.transformer) { image in }
         }
     }
 }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -166,12 +166,12 @@ extension PostCardProfilePic {
     func configure(user: UserCardModel, badgeIcon: UIImage? = nil) {
         self.user = user
         
+        if self.profileImageView.sd_currentImageURL?.absoluteString != user.imageURL {
+            self.profileImageView.sd_cancelCurrentImageLoad()
+        }
+        
         if let profileStr = user.imageURL, let profileURL = URL(string: profileStr) {
             let userForImage = user
-            
-            if self.profileImageView.sd_currentImageURL != profileURL {
-                self.profileImageView.sd_cancelCurrentImageLoad()
-            }
             
             self.profileImageView.ma_setImage(with: profileURL,
                                               cachedImage: self.user?.decodedProfilePic,
@@ -209,6 +209,16 @@ extension PostCardProfilePic {
     }
     
     func willDisplay() {
+        if self.profileImageView.sd_currentImageURL?.absoluteString != self.user?.imageURL {
+            self.profileImageView.sd_cancelCurrentImageLoad()
+            
+            if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
+                self.profileImageView.ma_setImage(with: profileURL,
+                                                  cachedImage: self.user?.decodedProfilePic,
+                                                  imageTransformer: PostCardProfilePic.transformer) { image in }
+            }
+        }
+        
         if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
             if self.profileImageView.sd_currentImageURL != profileURL {
                 self.profileImageView.sd_cancelCurrentImageLoad()

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -168,6 +168,11 @@ extension PostCardProfilePic {
         
         if let profileStr = user.imageURL, let profileURL = URL(string: profileStr) {
             let userForImage = user
+            
+            if self.profileImageView.sd_currentImageURL != profileURL {
+                self.profileImageView.sd_cancelCurrentImageLoad()
+            }
+            
             self.profileImageView.ma_setImage(with: profileURL,
                                               cachedImage: self.user?.decodedProfilePic,
                                               imageTransformer: PostCardProfilePic.transformer) { image in
@@ -200,6 +205,18 @@ extension PostCardProfilePic {
     @objc func profileTapped() {
         if let user = user {
             self.onPress?(.profile, true, .user(user))
+        }
+    }
+    
+    func willDisplay() {
+        if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
+            if self.profileImageView.sd_currentImageURL != profileURL {
+                self.profileImageView.sd_cancelCurrentImageLoad()
+            }
+            
+            self.profileImageView.ma_setImage(with: profileURL,
+                                              cachedImage: self.user?.decodedProfilePic,
+                                              imageTransformer: PostCardProfilePic.transformer) { image in }
         }
     }
 }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -218,16 +218,6 @@ extension PostCardProfilePic {
                                                   imageTransformer: PostCardProfilePic.transformer) { image in }
             }
         }
-        
-        if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
-            if self.profileImageView.sd_currentImageURL != profileURL {
-                self.profileImageView.sd_cancelCurrentImageLoad()
-                
-                self.profileImageView.ma_setImage(with: profileURL,
-                                                  cachedImage: self.user?.decodedProfilePic,
-                                                  imageTransformer: PostCardProfilePic.transformer) { image in }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
[MAM-3728 : Wrong Avatar/Images displayed while Feed loads](https://linear.app/theblvd/issue/MAM-3728/wrong-avatarimages-displayed-while-feed-loads)