### PR TITLE
Adding missing 'bookmarked' CodingKey to Status class

### DIFF
--- a/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
@@ -103,6 +103,7 @@ public class Status: Codable, Hashable {
         case favouritesCount = "favourites_count"
         case reblogged
         case favourited
+        case bookmarked
         case sensitive
         case spoilerText = "spoiler_text"
         case visibility


### PR DESCRIPTION
The `bookmarked` property was missing from the coding keys in the `Status` class, which means that no remotely bookmarked statuses would ever have their bookmarked property set true, preventing them from being correctly displayed, or capable of being removed within the app.

This is the updated PR with a signed commit.