### PR TITLE
MAM-3735-fix-crash-by-stripemojis-function

### DIFF
--- a/Mammoth/Utils/Extensions/String+StripEmojis.swift
+++ b/Mammoth/Utils/Extensions/String+StripEmojis.swift
@@ -16,9 +16,10 @@ extension String {
         
         // Iterate through matches in reverse order to correctly adjust indices
         for match in matches.reversed() {
-            let range = Range(match.range, in: self)!
-            let shortcode = self[range]
-            strippedText = strippedText.replacingOccurrences(of: String(shortcode), with: "")
+            if let range = Range(match.range, in: self) {
+                let shortcode = self[range]
+                strippedText = strippedText.replacingOccurrences(of: String(shortcode), with: "")
+            }
         }
         
         return strippedText.replaceDoubleSpaces()
@@ -31,8 +32,9 @@ extension String {
         
         // Iterate through matches in reverse order to correctly adjust indices
         for match in matches.reversed() {
-            let range = Range(match.range, in: self)!
-            strippedText = strippedText.replacingCharacters(in: range, with: "")
+            if let range = Range(match.range, in: self) {
+                strippedText = strippedText.replacingCharacters(in: range, with: "")
+            }
         }
         
         return strippedText.replaceDoubleSpaces()


### PR DESCRIPTION
pfefferle reports an instant crash on app launch.

[MAM-3735 : Fix crash by stripEmojis function](https://linear.app/theblvd/issue/MAM-3735/fix-crash-by-stripemojis-function)