### PR TITLE
MAM-3756-limit-preview-text-in-activity-to-two-lines

### DIFF
--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -69,9 +69,9 @@ final class ActivityCardCell: UITableViewCell {
         let label = MetaLabel()
         label.textColor = .custom.mediumContrast
         label.isOpaque = true
-        label.numberOfLines = 4
+        label.numberOfLines = 2
         label.textContainer.lineFragmentPadding = 0
-        label.textContainer.maximumNumberOfLines = 4
+        label.textContainer.maximumNumberOfLines = 2
         label.translatesAutoresizingMaskIntoConstraints = false
         
         label.textAttributes = [


### PR DESCRIPTION
[MAM-3756 : Limit preview text in activity to two lines](https://linear.app/theblvd/issue/MAM-3756/limit-preview-text-in-activity-to-two-lines)