### PR TITLE
MAM-3757-dont-show-thumbnails-for-likes-and-reposts-in-activity

### DIFF
--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -118,6 +118,15 @@ final class PostCardModel {
         case singleVideo
         case carousel
         case none
+        
+        var displayName: String? {
+            switch self {
+            case .singleImage: return "image"
+            case .singleVideo: return "video"
+            case .carousel: return "carousel"
+            default: return nil
+            }
+        }
     }
     
     enum QuotePostStatus: Int, CaseIterable, Equatable {

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -370,7 +370,7 @@ extension ActivityCardCell {
         
         
         if let postCard = activity.postCard {
-            let hideMedia = postCard.postText.isEmpty && [.favourite, .reblog].contains(activity.type)
+            let hideMedia = [.favourite, .reblog].contains(activity.type)
             
             // Display poll if needed
             if postCard.containsPoll {
@@ -387,7 +387,7 @@ extension ActivityCardCell {
             }
 
             // Display the quote post preview if needed
-            if postCard.hasQuotePost {
+            if postCard.hasQuotePost && !hideMedia {
                 if self.quotePost == nil {
                     self.quotePost = PostCardQuotePost(mediaVariant: .small)
                 }
@@ -401,7 +401,7 @@ extension ActivityCardCell {
             }
 
             // Display the link preview if needed
-            if postCard.hasLink && !postCard.hasQuotePost {
+            if postCard.hasLink && !postCard.hasQuotePost && !hideMedia {
                 if self.linkPreview == nil {
                     self.linkPreview = PostCardLinkPreview()
                 }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -401,7 +401,7 @@ extension ActivityCardCell {
             }
 
             // Display the link preview if needed
-            if postCard.hasLink && !postCard.hasQuotePost && !hideMedia {
+            if postCard.hasLink && !postCard.hasQuotePost {
                 if self.linkPreview == nil {
                     self.linkPreview = PostCardLinkPreview()
                 }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -358,14 +358,20 @@ extension ActivityCardCell {
             let content = MastodonContent(content: activity.user.userTag, emojis: [:])
             postTextLabel.configure(content: MastodonMetaContent.convert(text: content))
             postTextLabel.isUserInteractionEnabled = false
+            self.postTextLabel.isHidden = false
         default:
-            if let content = activity.postCard?.metaPostText {
+            if let postText = activity.postCard?.postText, postText.isEmpty {
+                self.postTextLabel.isHidden = true
+            } else if let content = activity.postCard?.metaPostText {
                 self.postTextLabel.configure(content: content)
+                self.postTextLabel.isHidden = false
             }
         }
         
         
         if let postCard = activity.postCard {
+            let hideMedia = postCard.postText.isEmpty && [.favourite, .reblog].contains(activity.type)
+            
             // Display poll if needed
             if postCard.containsPoll {
                 if self.poll == nil {
@@ -409,7 +415,7 @@ extension ActivityCardCell {
             }
             
             // Display single image if needed
-            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleImage {
+            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleImage && !hideMedia {
                 if self.image == nil {
                     self.image = PostCardImage(variant: .thumbnail)
                     self.image!.translatesAutoresizingMaskIntoConstraints = false
@@ -422,7 +428,7 @@ extension ActivityCardCell {
             }
             
             // Display single video/gif if needed
-            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
+            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo && !hideMedia {
                 if self.video == nil {
                     self.video = PostCardVideo(variant: .thumbnail)
                     self.video!.translatesAutoresizingMaskIntoConstraints = false
@@ -435,7 +441,7 @@ extension ActivityCardCell {
             }
 
             // Display the image carousel if needed
-            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .carousel {
+            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .carousel && !hideMedia {
                 if self.imageAttachment == nil {
                     self.imageAttachment = PostCardImageAttachment()
                 }
@@ -448,7 +454,7 @@ extension ActivityCardCell {
 
             // If we are hiding the link image, move the link view
             // so it's below any possible media.
-            if let linkPreview = self.linkPreview, postCard.hideLinkImage && mediaContainer.arrangedSubviews.contains(linkPreview) {
+            if let linkPreview = self.linkPreview, postCard.hideLinkImage && mediaContainer.arrangedSubviews.contains(linkPreview), !hideMedia {
                 mediaContainer.insertArrangedSubview(linkPreview, at: mediaContainer.arrangedSubviews.count - 1)
             }
         }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -204,9 +204,6 @@ extension ActivityCardHeader {
             if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasQuotePost {
                 return "liked your quote post"
             }
-            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasLink {
-                return "liked your link"
-            }
             return "liked"
         case .follow:
             return "followed you"
@@ -220,9 +217,6 @@ extension ActivityCardHeader {
             }
             if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasQuotePost {
                 return "reposted your quote post"
-            }
-            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasLink {
-                return "reposted your link"
             }
             return "reposted"
         case .status:

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -183,11 +183,24 @@ extension ActivityCardHeader {
         
         self.actionLabel.text = self.mapTypeToAction(activity: activity)
         self.dateLabel.text = activity.time
+        
+        if activity.type == .favourite, let text = activity.postCard?.postText, text.isEmpty {
+            headerTitleStackView.axis = .vertical
+            headerTitleStackView.alignment = .leading
+            headerTitleStackView.spacing = 0
+        } else {
+            headerTitleStackView.axis = .horizontal
+            headerTitleStackView.alignment = .center
+            headerTitleStackView.spacing = 5
+        }
     }
     
    private func mapTypeToAction(activity: ActivityCardModel) -> String {
         switch activity.type {
         case .favourite:
+            if let text = activity.postCard?.postText, text.isEmpty, let mediaType = activity.postCard?.mediaDisplayType.displayName {
+                return "liked your \(mediaType)"
+            }
             return "liked"
         case .follow:
             return "followed you"
@@ -196,6 +209,9 @@ extension ActivityCardHeader {
         case .poll:
             return "poll ended"
         case .reblog:
+            if let text = activity.postCard?.postText, text.isEmpty, let mediaType = activity.postCard?.mediaDisplayType.displayName {
+                return "reposted your \(mediaType)"
+            }
             return "reposted"
         case .status:
             return "posted"

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -184,7 +184,7 @@ extension ActivityCardHeader {
         self.actionLabel.text = self.mapTypeToAction(activity: activity)
         self.dateLabel.text = activity.time
         
-        if activity.type == .favourite, let text = activity.postCard?.postText, text.isEmpty {
+        if [.favourite, .reblog].contains(activity.type), let text = activity.postCard?.postText, text.isEmpty {
             headerTitleStackView.axis = .vertical
             headerTitleStackView.alignment = .leading
             headerTitleStackView.spacing = 0
@@ -201,6 +201,12 @@ extension ActivityCardHeader {
             if let text = activity.postCard?.postText, text.isEmpty, let mediaType = activity.postCard?.mediaDisplayType.displayName {
                 return "liked your \(mediaType)"
             }
+            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasQuotePost {
+                return "liked your quote post"
+            }
+            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasLink {
+                return "liked your link"
+            }
             return "liked"
         case .follow:
             return "followed you"
@@ -211,6 +217,12 @@ extension ActivityCardHeader {
         case .reblog:
             if let text = activity.postCard?.postText, text.isEmpty, let mediaType = activity.postCard?.mediaDisplayType.displayName {
                 return "reposted your \(mediaType)"
+            }
+            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasQuotePost {
+                return "reposted your quote post"
+            }
+            if let text = activity.postCard?.postText, text.isEmpty, let postCard = activity.postCard, postCard.hasLink {
+                return "reposted your link"
             }
             return "reposted"
         case .status:


### PR DESCRIPTION
[MAM-3757 : Don’t show thumbnails for likes and reposts in activity.](https://linear.app/theblvd/issue/MAM-3757/dont-show-thumbnails-for-likes-and-reposts-in-activity)

... also, don't show quote posts and link cards (https://linear.app/theblvd/issue/MAM-3757/dont-show-thumbnails-for-likes-and-reposts-in-activity)