### PR TITLE
MAM-3260-image-carousels-for-posts

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -143,7 +143,8 @@
 		14C45DF02B1A4266000171A9 /* Pride.png in Resources */ = {isa = PBXBuildFile; fileRef = 14C45DED2B1A4266000171A9 /* Pride.png */; };
 		14C45DF12B1A4266000171A9 /* Pride@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 14C45DEE2B1A4266000171A9 /* Pride@2x.png */; };
 		14E08C6A2B20BF9C00EF5A55 /* DeviceHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E08C692B20BF9C00EF5A55 /* DeviceHelpers.swift */; };
-		14F47F452B517DAB008F45CE /* PostCardImageStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F47F442B517DAB008F45CE /* PostCardImageStack.swift */; };
+		14F47F452B517DAB008F45CE /* PostCardMediaStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F47F442B517DAB008F45CE /* PostCardMediaStack.swift */; };
+		14F47F472B57F48B008F45CE /* PostCardMediaGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F47F462B57F48B008F45CE /* PostCardMediaGallery.swift */; };
 		532567AC2971C512004E7636 /* Timelines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53399A2B291526B900560F83 /* Timelines.swift */; };
 		532567F32971D250004E7636 /* OtherStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532567F22971D250004E7636 /* OtherStruct.swift */; };
 		532567FF2976FA3A004E7636 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532567FE2976FA3A004E7636 /* ShareViewController.swift */; };
@@ -952,7 +953,8 @@
 		14C45DED2B1A4266000171A9 /* Pride.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Pride.png; sourceTree = "<group>"; };
 		14C45DEE2B1A4266000171A9 /* Pride@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Pride@2x.png"; sourceTree = "<group>"; };
 		14E08C692B20BF9C00EF5A55 /* DeviceHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHelpers.swift; sourceTree = "<group>"; };
-		14F47F442B517DAB008F45CE /* PostCardImageStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardImageStack.swift; sourceTree = "<group>"; };
+		14F47F442B517DAB008F45CE /* PostCardMediaStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardMediaStack.swift; sourceTree = "<group>"; };
+		14F47F462B57F48B008F45CE /* PostCardMediaGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardMediaGallery.swift; sourceTree = "<group>"; };
 		532567F22971D250004E7636 /* OtherStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherStruct.swift; sourceTree = "<group>"; };
 		532567FC2976FA3A004E7636 /* Mammoth Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Mammoth Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		532567FE2976FA3A004E7636 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -3099,16 +3101,17 @@
 				C3D3C4792A30DEB3007B31EE /* PostCardHeader.swift */,
 				C3D3C47E2A336EC6007B31EE /* PostCardHeaderExtension.swift */,
 				C3085A142AC5C6CD007E1CFD /* PostCardImage.swift */,
-				C311EACF2ACAE1DA005B5708 /* PostCardVideo.swift */,
 				C37881D22A214D450053A586 /* PostCardImageAttachment.swift */,
 				BF5F97F12A23E0C500014DF3 /* PostCardImageCollectionCell.swift */,
 				BF5F97F32A259DBF00014DF3 /* PostCardImageCollectionCellSmall.swift */,
 				C316428C2A27584D00DCB4A3 /* PostCardLinkPreview.swift */,
+				14F47F462B57F48B008F45CE /* PostCardMediaGallery.swift */,
+				14F47F442B517DAB008F45CE /* PostCardMediaStack.swift */,
+				C3085A032AC42EEF007E1CFD /* PostCardMetadata.swift */,
 				C3FD55062A2F6954000EA8A4 /* PostCardPoll.swift */,
 				C3B693C02A38748300E85927 /* PostCardProfilePic.swift */,
 				C3B5A5D72A30B9AD00427C73 /* PostCardQuotePost.swift */,
-				C3085A032AC42EEF007E1CFD /* PostCardMetadata.swift */,
-				14F47F442B517DAB008F45CE /* PostCardImageStack.swift */,
+				C311EACF2ACAE1DA005B5708 /* PostCardVideo.swift */,
 			);
 			path = PostCardCell;
 			sourceTree = "<group>";
@@ -3630,6 +3633,7 @@
 				532567AC2971C512004E7636 /* Timelines.swift in Sources */,
 				662B60E62A4A1EFC00CB331F /* BlueskyAPI+Graph.swift in Sources */,
 				C3C7ED282A5D61B70039FB4D /* String+Filename.swift in Sources */,
+				14F47F472B57F48B008F45CE /* PostCardMediaGallery.swift in Sources */,
 				53399A34291526B900560F83 /* ClientType.swift in Sources */,
 				53399A61291526B900560F83 /* Mutes.swift in Sources */,
 				53399A77291526B900560F83 /* Request.swift in Sources */,
@@ -3665,7 +3669,7 @@
 				533994B82914214A00560F83 /* TranslationComposeViewController.swift in Sources */,
 				53450E662936127C00D720EA /* CustomDateFormatTransform.swift in Sources */,
 				533994D32914214A00560F83 /* FiltersViewController.swift in Sources */,
-				14F47F452B517DAB008F45CE /* PostCardImageStack.swift in Sources */,
+				14F47F452B517DAB008F45CE /* PostCardMediaStack.swift in Sources */,
 				C37E6D432A6559C30038B5F6 /* Sequence+Async.swift in Sources */,
 				BFDCBD1A2A9D61BB00606234 /* ChannelsViewModel.swift in Sources */,
 				533996DA2914227A00560F83 /* CropViewController.swift in Sources */,

--- a/Mammoth/Screens/External/SKPhotoBrowser/SKPhoto.swift
+++ b/Mammoth/Screens/External/SKPhotoBrowser/SKPhoto.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SDWebImage
 
 @objc public protocol SKPhotoProtocol: NSObjectProtocol {
     var index: Int { get set }

--- a/Mammoth/Screens/External/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/Mammoth/Screens/External/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -123,7 +123,7 @@ open class SKPhotoBrowser: UIViewController, UIContextMenuInteractionDelegate, U
         animator.senderViewForAnimation = animatedFromView
         
         self.currentPageIndex = currentIndex
-        self.imageText = descriptions[currentIndex]
+        self.imageText = descriptions.count > currentIndex ? descriptions[currentIndex] : nil
         self.imageText2 = 0
         self.imageText3 = 0
         self.imageText4 = ""

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -699,7 +699,7 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
         
         let updateDisplay = (NewsFeedTypes.allActivityTypes + [.mentionsIn, .mentionsOut]).contains(feedType) || self.isInWindowHierarchy()
         
-        guard !self.tableView.isDragging, updateDisplay else {
+        guard !self.tableView.isTracking, updateDisplay else {
             let deferredJob = {  [weak self] in
                 guard let self else { return }
                 self.didUpdateSnapshot(snapshot, feedType: feedType, updateType: updateType, onCompleted: onCompleted)

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -328,14 +328,12 @@ final class PostCardCell: UITableViewCell {
     private var videoTrailingConstraint: NSLayoutConstraint? = nil
     
     private var mediaGallery: PostCardMediaGallery?
-    private var mediaGalleryLeadingConstraint: NSLayoutConstraint? = nil
     private var mediaGalleryTrailingConstraint: NSLayoutConstraint? = nil
     
     private var mediaStack: PostCardMediaStack?
     private var mediaStackTrailingConstraint: NSLayoutConstraint? = nil
     
     private var linkPreview: PostCardLinkPreview?
-    private var linkPreviewLeadingConstraint: NSLayoutConstraint? = nil
     private var linkPreviewTrailingConstraint: NSLayoutConstraint? = nil
     
     private var quotePost: PostCardQuotePost?
@@ -431,14 +429,6 @@ final class PostCardCell: UITableViewCell {
         self.linkPreview?.prepareForReuse()
         self.mediaStack?.prepareForReuse()
         self.mediaGallery?.prepareForReuse()
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        let marginLeft = self.convert(self.mainStackView.frame.origin, to: self.mediaContainer).x
-        self.mediaGalleryLeadingConstraint?.constant = marginLeft
-        self.mediaGallery?.leftInset = marginLeft * -1
-        self.mediaGalleryTrailingConstraint?.constant = contentView.layoutMargins.right
     }
 }
 
@@ -572,7 +562,6 @@ private extension PostCardCell {
                 self.mediaGallery?.translatesAutoresizingMaskIntoConstraints = false
                 mediaContainer.addArrangedSubview(self.mediaGallery!)
                 mediaGalleryTrailingConstraint = mediaGalleryTrailingConstraint ?? self.mediaGallery!.trailingAnchor.constraint(equalTo: mediaContainer.trailingAnchor)
-                self.mediaGalleryLeadingConstraint = mediaGalleryLeadingConstraint ?? self.mediaGallery!.leadingAnchor.constraint(equalTo: self.mediaContainer.leadingAnchor, constant: 0)
             default: break
             }
             
@@ -581,7 +570,6 @@ private extension PostCardCell {
             self.linkPreview = PostCardLinkPreview()
             self.linkPreview?.translatesAutoresizingMaskIntoConstraints = false
             mediaContainer.addArrangedSubview(self.linkPreview!)
-            linkPreviewLeadingConstraint = linkPreviewLeadingConstraint ?? self.linkPreview!.leadingAnchor.constraint(equalTo: mediaContainer.layoutMarginsGuide.leadingAnchor)
             linkPreviewTrailingConstraint = linkPreviewTrailingConstraint ?? self.linkPreview!.trailingAnchor.constraint(equalTo: mediaContainer.layoutMarginsGuide.trailingAnchor)
             
             // Setup Poll
@@ -922,14 +910,8 @@ extension PostCardCell {
                 if let constraint = self.linkPreviewTrailingConstraint, !constraint.isActive {
                     NSLayoutConstraint.activate([constraint])
                 }
-                if let constraint = self.linkPreviewLeadingConstraint, !constraint.isActive {
-                    NSLayoutConstraint.activate([constraint])
-                }
             } else {
                 if let constraint = self.linkPreviewTrailingConstraint, constraint.isActive {
-                    NSLayoutConstraint.deactivate([constraint])
-                }
-                if let constraint = self.linkPreviewLeadingConstraint, constraint.isActive {
                     NSLayoutConstraint.deactivate([constraint])
                 }
             }
@@ -965,16 +947,10 @@ extension PostCardCell {
                     }
                     NSLayoutConstraint.deactivate([
                         self.mediaGalleryTrailingConstraint,
-                        self.mediaGalleryLeadingConstraint
                     ].compactMap({$0}))
                 case .large:
                     if let constraint = self.mediaGalleryTrailingConstraint, !constraint.isActive {
-                        let marginLeft = self.convert(self.mainStackView.frame.origin, to: self.mediaContainer).x
-                        self.mediaGalleryLeadingConstraint?.constant = marginLeft
-                        self.mediaGallery?.leftInset = marginLeft * -1
-                        
                         NSLayoutConstraint.activate([
-                            self.mediaGalleryLeadingConstraint!,
                             self.mediaGalleryTrailingConstraint!
                         ])
                     }
@@ -987,7 +963,6 @@ extension PostCardCell {
             } else {
                 NSLayoutConstraint.deactivate([
                     self.mediaGalleryTrailingConstraint,
-                    self.mediaGalleryLeadingConstraint
                 ].compactMap({$0}))
             }
         }
@@ -1062,7 +1037,6 @@ extension PostCardCell {
             self.postTextView.text = "\(batchId) - \(batchItemIndex)"
             
             if let mediaGallery = self.mediaGallery {
-                self.mediaGalleryLeadingConstraint?.isActive = false
                 self.mediaGalleryTrailingConstraint?.isActive = false
                 self.mediaContainer.removeArrangedSubview(mediaGallery)
                 mediaGallery.removeFromSuperview()
@@ -1070,7 +1044,6 @@ extension PostCardCell {
             
             if let linkPreview = self.linkPreview {
                 self.linkPreviewTrailingConstraint?.isActive = false
-                self.linkPreviewLeadingConstraint?.isActive = false
                 self.mediaContainer.removeArrangedSubview(linkPreview)
                 linkPreview.removeFromSuperview()
                 linkPreview.prepareForReuse()

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -224,7 +224,7 @@ final class PostCardCell: UITableViewCell {
     private var contentStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.alignment = .top
+        stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.spacing = 2
         stackView.isOpaque = true

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -297,11 +297,16 @@ final class PostCardImage: UIView {
     @objc func onPress() {
         if let originImage = imageView.image {
             
+            // Preload other images
+            let prefetcher = SDWebImagePrefetcher.shared
+            let urls = self.postCard?.mediaAttachments.compactMap { URL(string: $0.url) }
+            prefetcher.prefetchURLs(urls, progress: nil)
+            
             // Open fullscreen image preview
             let images = self.postCard?.mediaAttachments.compactMap { attachment in
                 guard attachment.type == .image else { return nil }
                 let photo = SKPhoto.photoWithImageURL(attachment.url)
-                photo.shouldCachePhotoURLImage = true
+                photo.underlyingImage = SDImageCache.shared.imageFromCache(forKey: attachment.url)
                 return photo
             } ?? [SKPhoto()]
             

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -130,6 +130,7 @@ final class PostCardImage: UIView {
         return button
     }()
     
+    private var postCard: PostCardModel?
     private var media: Attachment?
     private let variant: PostCardImageVariant
     
@@ -144,6 +145,7 @@ final class PostCardImage: UIView {
     }
     
     func prepareForReuse() {
+        self.postCard = nil
         self.media = nil
         self.dismissedSensitiveOverlay = false
         self.imageView.sd_cancelCurrentImageLoad()
@@ -191,22 +193,26 @@ final class PostCardImage: UIView {
         
     }
     
-    public func configure(postCard: PostCardModel) {
-        let shouldUpdate = self.media == nil || postCard.mediaAttachments.first != self.media!
+    public func configure(image: Attachment?, postCard: PostCardModel) {
+        let shouldUpdate = self.media == nil || image != self.media!
+        self.postCard = postCard
         
-        if let media = postCard.mediaAttachments.first {
+        if let media = image {
             self.media = media
             if let previewURL = media.previewURL, let imageURL = URL(string: previewURL) {
                 var placeholder: UIImage?
                 if let blurhash = media.blurhash {
                     placeholder = UnifiedImage(blurHash: blurhash, size: .init(width: 32, height: 32))
                 }
+                let decodedImage = (media.previewURL != nil) ? postCard.decodedImages[media.previewURL!] as? UIImage : nil
                 self.imageView.ma_setImage(with: imageURL,
-                                           cachedImage: postCard.decodedImages[previewURL] as? UIImage,
+                                           cachedImage: decodedImage,
                                            placeholder: placeholder,
                                                   imageTransformer: PostCardImage.transformer) { [weak self] image in
-                    if self?.media == media {
-                        postCard.decodedImages[previewURL] = image
+                    if self?.media == media, let image = image {
+                        if let key = media.previewURL {
+                            postCard.decodedImages[key] = image
+                        }
                     }
                 }
             }
@@ -273,6 +279,12 @@ final class PostCardImage: UIView {
         }
     }
     
+    public func configure(postCard: PostCardModel) {
+        if let firstImage = postCard.mediaAttachments.first {
+            self.configure(image: firstImage, postCard: postCard)
+        }
+    }
+    
     private func deactivateAllImageConstraints() {
         NSLayoutConstraint.deactivate(self.squareConstraints
                                       + self.portraitConstraints
@@ -285,16 +297,22 @@ final class PostCardImage: UIView {
     @objc func onPress() {
         if let originImage = imageView.image {
             
-            let photo: SKPhoto = {
-                if let url = media?.url {
-                    let photo = SKPhoto.photoWithImageURL(url)
-                    photo.shouldCachePhotoURLImage = true
-                    return photo
-                }
-                return SKPhoto()
-            }()
+            // Open fullscreen image preview
+            let images = self.postCard?.mediaAttachments.compactMap { attachment in
+                guard attachment.type == .image else { return nil }
+                let photo = SKPhoto.photoWithImageURL(attachment.url)
+                photo.shouldCachePhotoURLImage = true
+                return photo
+            } ?? [SKPhoto()]
             
-            let browser = SKPhotoBrowser(originImage: originImage, photos: [photo], animatedFromView: imageView, imageText: media?.description ?? "", imageText2: 0, imageText3: 0, imageText4: "")
+            let descriptions = self.postCard?.mediaAttachments.map { $0.description ?? "" } ?? []
+            let currentIndex = self.postCard?.mediaAttachments.firstIndex(where: {$0.id == self.media?.id}) ?? 0
+            
+            let browser = SKPhotoBrowser(originImage: originImage,
+                                         photos: images,
+                                         animatedFromView: self.imageView,
+                                         descriptions: descriptions,
+                                         currentIndex: currentIndex)
             SKPhotoBrowserOptions.enableSingleTapDismiss = false
             SKPhotoBrowserOptions.displayCounterLabel = false
             SKPhotoBrowserOptions.displayBackAndForwardButton = false
@@ -303,7 +321,7 @@ final class PostCardImage: UIView {
             SKPhotoBrowserOptions.displayVerticalScrollIndicator = false
             SKPhotoBrowserOptions.displayCloseButton = false
             SKPhotoBrowserOptions.displayStatusbar = false
-            browser.initializePageIndex(0)
+            browser.initializePageIndex(currentIndex)
             getTopMostViewController()?.present(browser, animated: true, completion: {})
         }
     }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -51,11 +51,14 @@ final class PostCardMediaGallery: UIView {
         
         scrollView.addSubview(stackView)
         stackView.pinEdges()
-                
-        NSLayoutConstraint.activate([
-            scrollView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight),
-            stackView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
-        ])
+        
+        let scrollViewHeight = scrollView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
+        scrollViewHeight.isActive = true
+        scrollViewHeight.priority = .required
+        
+        let stackViewHeight = stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor)
+        stackViewHeight.isActive = true
+        stackViewHeight.priority = .required
     }
 }
 
@@ -83,7 +86,10 @@ extension PostCardMediaGallery {
                 }
                 
                 if media.type == .video || media.type == .gifv || media.type == .audio {
-                    
+                    let video = PostCardVideo()
+                    video.configure(video: media, postCard: postCard)
+                    video.pause()
+                    self.stackView.addArrangedSubview(video)
                 }
             })
         }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -13,46 +13,28 @@ import UnifiedBlurHash
 fileprivate let PostCardMediaGalleryHeight = 180.0
 
 final class PostCardMediaGallery: UIView {
-    
-    private lazy var collectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.layout)
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.delegate = self
-        collectionView.dataSource = self
-        collectionView.clipsToBounds = false
-        collectionView.isPagingEnabled = false
-        collectionView.register(PostCardMediaGalleryItem.self, forCellWithReuseIdentifier: PostCardMediaGalleryItem.reuseIdentifier)
-        collectionView.accessibilityIdentifier = "mediaGallery"
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.decelerationRate = .fast
-        collectionView.backgroundColor = .clear
-        return collectionView
+
+    private let scrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = false
+        view.showsVerticalScrollIndicator = false
+        view.showsHorizontalScrollIndicator = false
+        return view
     }()
     
-    private lazy var layout = PostCardMediaGalleryFlowLayout()
-    
-    private var cellWidths: [Float] {
-        self.postCard?.mediaAttachments.enumerated().map({
-            let index = $0.offset
-            return Float(self.calculateCellWidth(for: IndexPath(item: index, section: 0)))
-        }) ?? []
-    }
-    
-    fileprivate var cellOffsets: [Float] {
-        calculateOffsets(for: self.cellWidths, additionalItemOffset: Float(self.layout.minimumLineSpacing))
-    }
-    private let cellHeight: CGFloat = 180.0
-    private let targetAspectRatio: CGFloat = 16.0 / 9.0
-    
-    private var media: Attachment?
+    private let stackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 8.0
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private var attachments: [Attachment]?
     private var postCard: PostCardModel?
-    
-    public var leftInset: CGFloat = 0 {
-        didSet {
-            self.layout.sectionInset = UIEdgeInsets(top: 0, left: leftInset, bottom: 0, right: 13)
-        }
-    }
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -64,227 +46,46 @@ final class PostCardMediaGallery: UIView {
     }
     
     private func setupUI() {
-        self.addSubview(collectionView)
-        self.collectionView.pinEdges()
+        self.addSubview(scrollView)
+        scrollView.pinEdges()
         
+        scrollView.addSubview(stackView)
+        stackView.pinEdges()
+                
         NSLayoutConstraint.activate([
-            self.collectionView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
+            scrollView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight),
+            stackView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
         ])
     }
 }
 
 extension PostCardMediaGallery {
     func prepareForReuse() {
-        self.media = nil
+        self.attachments = nil
         self.postCard = nil
+        self.stackView.arrangedSubviews.forEach({
+            self.stackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        })
     }
     
     public func configure(postCard: PostCardModel) {
-        let shouldUpdate = self.media == nil || postCard.mediaAttachments.first != self.media!
-        self.media = postCard.mediaAttachments.first
+        let shouldUpdate = self.attachments == nil || postCard.mediaAttachments != self.attachments!
+        self.attachments = postCard.mediaAttachments
         self.postCard = postCard
         
         if shouldUpdate {
-            if let media = self.media {
+            self.attachments?.forEach({ media in
                 if media.type == .image {
-                    
+                    let image = PostCardImage()
+                    image.configure(image: media, postCard: postCard)
+                    self.stackView.addArrangedSubview(image)
                 }
                 
                 if media.type == .video || media.type == .gifv || media.type == .audio {
                     
                 }
-                
-                self.collectionView.reloadData()
-            }
+            })
         }
     }
-}
-
-extension PostCardMediaGallery: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.postCard?.mediaAttachments.count ?? 0
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostCardMediaGalleryItem.reuseIdentifier, for: indexPath) as? PostCardMediaGalleryItem, let postCard = self.postCard, let model = self.postCard?.mediaAttachments[indexPath.item] {
-            cell.configure(attachment: model, postCard: postCard)
-            return cell
-        }
-        
-        log.error("Unable to configure PostCardMediaGallery item")
-        return UICollectionViewCell()
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = calculateCellWidth(for: indexPath)
-        return CGSize(width: width, height: cellHeight)
-    }
-    
-    private func calculateCellWidth(for indexPath: IndexPath) -> CGFloat {
-        if let attachment = self.postCard?.mediaAttachments[indexPath.item] {
-            // the aspect value might be nil
-            if attachment.meta?.original?.aspect == nil {
-                attachment.meta?.original?.aspect = Double(attachment.meta?.original?.width ?? 10) / Double(attachment.meta?.original?.height ?? 10)
-            }
-            
-            if let ratio = attachment.meta?.original?.aspect {
-                if fabs(ratio - 1.0) < 0.01 {
-                    return PostCardMediaGalleryHeight
-                }
-                
-                // landscape
-                else if ratio > 1 {
-                    return PostCardMediaGalleryHeight * ratio
-                }
-                
-                // portrait
-                else if ratio < 1 {
-                    return PostCardMediaGalleryHeight * ratio
-                }
-            }
-        }
-        return 0.0
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-    }
-    
-}
-
-fileprivate class PostCardMediaGalleryFlowLayout: UICollectionViewFlowLayout {
-    
-    override init() {
-        super.init()
-        
-        self.minimumLineSpacing = 8
-        self.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        self.scrollDirection = .horizontal
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
-        guard let _ = collectionView else { return proposedContentOffset }
-        if let mediaGallery = self.collectionView?.superview as? PostCardMediaGallery {
-            let offsets = mediaGallery.cellOffsets
-            if let index = findClosestIndex(array: offsets, target: Float(proposedContentOffset.x)) {
-                return CGPoint(x: Int(offsets[index]), y: 0)
-            }
-        }
-
-        return proposedContentOffset
-    }
-    
-}
-
-
-fileprivate class PostCardMediaGalleryItem: UICollectionViewCell {
-    
-    static let reuseIdentifier: String = "PostCardMediaGalleryItem"
-    
-    private let imageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFill
-        imageView.layer.cornerRadius = 8
-        imageView.layer.cornerCurve = .continuous
-        imageView.layer.masksToBounds = true
-        imageView.backgroundColor = .red
-        imageView.clipsToBounds = true
-        return imageView
-    }()
-    
-    private var dynamicWidthConstraint: NSLayoutConstraint?
-    
-    override init(frame: CGRect) {
-        super.init(frame: .zero)
-        self.setupUI()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        self.imageView.sd_cancelCurrentImageLoad()
-        self.imageView.image = nil
-        self.dynamicWidthConstraint?.isActive = false
-        
-    }
-    
-    private func setupUI() {
-        self.contentView.addSubview(imageView)
-        self.contentView.layoutMargins = .zero
-        
-        NSLayoutConstraint.activate([
-            imageView.leadingAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.leadingAnchor),
-            imageView.topAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.topAnchor),
-            imageView.trailingAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.bottomAnchor),
-            imageView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
-        ])
-    }
-}
-
-extension PostCardMediaGalleryItem {
-    public func configure(attachment: Attachment, postCard: PostCardModel) {
-        
-        var placeholder: UIImage?
-        if let blurhash = attachment.blurhash {
-            placeholder = UnifiedImage(blurHash: blurhash, size: .init(width: 32, height: 32))
-        }
-        
-        self.imageView.ma_setImage(with: URL(string: attachment.previewURL!)!,
-                                          cachedImage: postCard.decodedImages[attachment.previewURL!] as? UIImage,
-                                          placeholder: placeholder,
-                                          imageTransformer: PostCardImage.transformer) { image in
-            postCard.decodedImages[attachment.previewURL!] = image
-        }
-        
-//        self.dynamicWidthConstraint = self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor, multiplier: 16.0/9.0)
-//        self.dynamicWidthConstraint?.isActive = true
-//        self.dynamicWidthConstraint?.priority = .required
-    }
-}
-
-// MARK: - Helper functions
-
-func calculateOffsets(for inputArray: [Float], additionalItemOffset: Float = 0) -> [Float] {
-    var outputArray: [Float] = []
-
-    for (index, value) in inputArray.enumerated() {
-        if index == 0 {
-            outputArray.append(0)
-        } else {
-            let previousWidth = inputArray[index - 1]
-            let previousSum = outputArray[index - 1]
-            let currentSum = previousSum + additionalItemOffset + previousWidth
-            outputArray.append(currentSum)
-        }
-    }
-
-    return outputArray
-}
-
-func findClosestIndex(array: [Float], target: Float) -> Int? {
-    guard !array.isEmpty else {
-        return nil
-    }
-
-    var closestIndex = 0
-    var closestDifference = abs(array[0] - target)
-
-    for (index, width) in array.enumerated() {
-        let difference = abs(width - target)
-        if difference < closestDifference {
-            closestIndex = index
-            closestDifference = difference
-        }
-    }
-
-    return closestIndex
 }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -1,0 +1,290 @@
+//
+//  PostCardMediaGallery.swift
+//  Mammoth
+//
+//  Created by Benoit Nolens on 17/01/2024
+//  Copyright © 2024 The BLVD. All rights reserved.
+//
+
+import UIKit
+import SDWebImage
+import UnifiedBlurHash
+
+fileprivate let PostCardMediaGalleryHeight = 180.0
+
+final class PostCardMediaGallery: UIView {
+    
+    private lazy var collectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.layout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.clipsToBounds = false
+        collectionView.isPagingEnabled = false
+        collectionView.register(PostCardMediaGalleryItem.self, forCellWithReuseIdentifier: PostCardMediaGalleryItem.reuseIdentifier)
+        collectionView.accessibilityIdentifier = "mediaGallery"
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.decelerationRate = .fast
+        collectionView.backgroundColor = .clear
+        return collectionView
+    }()
+    
+    private lazy var layout = PostCardMediaGalleryFlowLayout()
+    
+    private var cellWidths: [Float] {
+        self.postCard?.mediaAttachments.enumerated().map({
+            let index = $0.offset
+            return Float(self.calculateCellWidth(for: IndexPath(item: index, section: 0)))
+        }) ?? []
+    }
+    
+    fileprivate var cellOffsets: [Float] {
+        calculateOffsets(for: self.cellWidths, additionalItemOffset: Float(self.layout.minimumLineSpacing))
+    }
+    private let cellHeight: CGFloat = 180.0
+    private let targetAspectRatio: CGFloat = 16.0 / 9.0
+    
+    private var media: Attachment?
+    private var postCard: PostCardModel?
+    
+    public var leftInset: CGFloat = 0 {
+        didSet {
+            self.layout.sectionInset = UIEdgeInsets(top: 0, left: leftInset, bottom: 0, right: 13)
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        self.setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        self.addSubview(collectionView)
+        self.collectionView.pinEdges()
+        
+        NSLayoutConstraint.activate([
+            self.collectionView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
+        ])
+    }
+}
+
+extension PostCardMediaGallery {
+    func prepareForReuse() {
+        self.media = nil
+        self.postCard = nil
+    }
+    
+    public func configure(postCard: PostCardModel) {
+        let shouldUpdate = self.media == nil || postCard.mediaAttachments.first != self.media!
+        self.media = postCard.mediaAttachments.first
+        self.postCard = postCard
+        
+        if shouldUpdate {
+            if let media = self.media {
+                if media.type == .image {
+                    
+                }
+                
+                if media.type == .video || media.type == .gifv || media.type == .audio {
+                    
+                }
+                
+                self.collectionView.reloadData()
+            }
+        }
+    }
+}
+
+extension PostCardMediaGallery: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.postCard?.mediaAttachments.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostCardMediaGalleryItem.reuseIdentifier, for: indexPath) as? PostCardMediaGalleryItem, let postCard = self.postCard, let model = self.postCard?.mediaAttachments[indexPath.item] {
+            cell.configure(attachment: model, postCard: postCard)
+            return cell
+        }
+        
+        log.error("Unable to configure PostCardMediaGallery item")
+        return UICollectionViewCell()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = calculateCellWidth(for: indexPath)
+        return CGSize(width: width, height: cellHeight)
+    }
+    
+    private func calculateCellWidth(for indexPath: IndexPath) -> CGFloat {
+        if let attachment = self.postCard?.mediaAttachments[indexPath.item] {
+            // the aspect value might be nil
+            if attachment.meta?.original?.aspect == nil {
+                attachment.meta?.original?.aspect = Double(attachment.meta?.original?.width ?? 10) / Double(attachment.meta?.original?.height ?? 10)
+            }
+            
+            if let ratio = attachment.meta?.original?.aspect {
+                if fabs(ratio - 1.0) < 0.01 {
+                    return PostCardMediaGalleryHeight
+                }
+                
+                // landscape
+                else if ratio > 1 {
+                    return PostCardMediaGalleryHeight * ratio
+                }
+                
+                // portrait
+                else if ratio < 1 {
+                    return PostCardMediaGalleryHeight * ratio
+                }
+            }
+        }
+        return 0.0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+    }
+    
+}
+
+fileprivate class PostCardMediaGalleryFlowLayout: UICollectionViewFlowLayout {
+    
+    override init() {
+        super.init()
+        
+        self.minimumLineSpacing = 8
+        self.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        self.scrollDirection = .horizontal
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
+        guard let _ = collectionView else { return proposedContentOffset }
+        if let mediaGallery = self.collectionView?.superview as? PostCardMediaGallery {
+            let offsets = mediaGallery.cellOffsets
+            if let index = findClosestIndex(array: offsets, target: Float(proposedContentOffset.x)) {
+                return CGPoint(x: Int(offsets[index]), y: 0)
+            }
+        }
+
+        return proposedContentOffset
+    }
+    
+}
+
+
+fileprivate class PostCardMediaGalleryItem: UICollectionViewCell {
+    
+    static let reuseIdentifier: String = "PostCardMediaGalleryItem"
+    
+    private let imageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.layer.cornerCurve = .continuous
+        imageView.layer.masksToBounds = true
+        imageView.backgroundColor = .red
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+    
+    private var dynamicWidthConstraint: NSLayoutConstraint?
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        self.setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.imageView.sd_cancelCurrentImageLoad()
+        self.imageView.image = nil
+        self.dynamicWidthConstraint?.isActive = false
+        
+    }
+    
+    private func setupUI() {
+        self.contentView.addSubview(imageView)
+        self.contentView.layoutMargins = .zero
+        
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.leadingAnchor),
+            imageView.topAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.topAnchor),
+            imageView.trailingAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.bottomAnchor),
+            imageView.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
+        ])
+    }
+}
+
+extension PostCardMediaGalleryItem {
+    public func configure(attachment: Attachment, postCard: PostCardModel) {
+        
+        var placeholder: UIImage?
+        if let blurhash = attachment.blurhash {
+            placeholder = UnifiedImage(blurHash: blurhash, size: .init(width: 32, height: 32))
+        }
+        
+        self.imageView.ma_setImage(with: URL(string: attachment.previewURL!)!,
+                                          cachedImage: postCard.decodedImages[attachment.previewURL!] as? UIImage,
+                                          placeholder: placeholder,
+                                          imageTransformer: PostCardImage.transformer) { image in
+            postCard.decodedImages[attachment.previewURL!] = image
+        }
+        
+//        self.dynamicWidthConstraint = self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor, multiplier: 16.0/9.0)
+//        self.dynamicWidthConstraint?.isActive = true
+//        self.dynamicWidthConstraint?.priority = .required
+    }
+}
+
+// MARK: - Helper functions
+
+func calculateOffsets(for inputArray: [Float], additionalItemOffset: Float = 0) -> [Float] {
+    var outputArray: [Float] = []
+
+    for (index, value) in inputArray.enumerated() {
+        if index == 0 {
+            outputArray.append(0)
+        } else {
+            let previousWidth = inputArray[index - 1]
+            let previousSum = outputArray[index - 1]
+            let currentSum = previousSum + additionalItemOffset + previousWidth
+            outputArray.append(currentSum)
+        }
+    }
+
+    return outputArray
+}
+
+func findClosestIndex(array: [Float], target: Float) -> Int? {
+    guard !array.isEmpty else {
+        return nil
+    }
+
+    var closestIndex = 0
+    var closestDifference = abs(array[0] - target)
+
+    for (index, width) in array.enumerated() {
+        let difference = abs(width - target)
+        if difference < closestDifference {
+            closestIndex = index
+            closestDifference = difference
+        }
+    }
+
+    return closestIndex
+}

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
@@ -160,7 +160,7 @@ final class PostCardMediaStack: UIView {
                 return photo
             } ?? [SKPhoto()]
             
-            let descriptions = self.postCard?.mediaAttachments.map { $0.description } ?? []
+            let descriptions = self.postCard?.mediaAttachments.map { $0.description ?? "" } ?? []
             
             let browser = SKPhotoBrowser(originImage: originImage,
                                          photos: images,

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
@@ -1,5 +1,5 @@
 //
-//  PostCardImageStack.swift
+//  PostCardMediaStack.swift
 //  Mammoth
 //
 //  Created by Benoit Nolens on 12/01/2024
@@ -10,7 +10,7 @@ import UIKit
 import UnifiedBlurHash
 import AVFoundation
 
-final class PostCardImageStack: UIView {
+final class PostCardMediaStack: UIView {
     
     enum PostCardImageStackVariant {
         case fullSize
@@ -136,7 +136,7 @@ final class PostCardImageStack: UIView {
                     // Audio is currenlty using a carousel view in large-mode.
                     // To make this work in small-mode using this image stack
                     // we hide the backgroundCard if it's an audio track alone.
-                    // @FIX: when audio has it's own view
+                    // FIX: when audio has it's own view
                     if media.type == .audio && postCard.mediaAttachments.count == 1 {
                         self.backgroundCard.isHidden = true
                     }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardVideo.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardVideo.swift
@@ -215,6 +215,7 @@ final class PostCardVideo: UIView {
     
     private var isSystemPaused: Bool = false
         
+    private var postCard: PostCardModel?
     private var media: Attachment?
     private var isSensitive: Bool = false
     private let variant: PostCardVideoVariant
@@ -243,6 +244,7 @@ final class PostCardVideo: UIView {
     }
     
     func prepareForReuse() {
+        self.postCard = nil
         self.media = nil
         self.isSensitive = false
         self.dismissedSensitiveOverlay = false
@@ -442,10 +444,11 @@ final class PostCardVideo: UIView {
         super.updateConstraints()
     }
     
-    public func configure(postCard: PostCardModel) {
+    public func configure(video: Attachment?, postCard: PostCardModel, cachedPlayer: AVPlayer? = nil) {
         self.isSensitive = postCard.isSensitive
+        self.postCard = postCard
         
-        if let media = postCard.mediaAttachments.first {
+        if let media = video {
             guard self.media != media else { return }
             
             self.media = media
@@ -454,7 +457,7 @@ final class PostCardVideo: UIView {
                 loadingIndicator.startAnimating()
                 previewImage.sd_setImage(with: previewImageURL)
                 
-                if let cachedPlayer = postCard.videoPlayer {
+                if let cachedPlayer = cachedPlayer {
                     // if the player is preloaded
                     player = cachedPlayer
                     
@@ -542,6 +545,12 @@ final class PostCardVideo: UIView {
             }
             
             self.setNeedsUpdateConstraints()
+        }
+    }
+    
+    public func configure(postCard: PostCardModel) {
+        if let firstVideo = postCard.mediaAttachments.first, [.video, .gifv].contains(firstVideo.type) {
+            self.configure(video: firstVideo, postCard: postCard, cachedPlayer: postCard.videoPlayer)
         }
     }
     


### PR DESCRIPTION
[MAM-3260 : Image carousels for posts ✨](https://linear.app/theblvd/issue/MAM-3260/image-carousels-for-posts-✨)

MISSING:
- Missing a fixed aspect ratio lock when the original image or video is outside the 16/9 or 9/16 ratio
- In some cases videos are not displayed in their right aspect ratio
- accept swipes outside the gallery frame when the touch is on content of the scrollview (overriding hitTest)