### PR TITLE
MAM-3352-links-on-profiles-not-working-build-340

### DIFF
--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -62,6 +62,10 @@ class ProfileViewController: UIViewController, UIScrollViewDelegate, UITableView
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self
+        self.header.onButtonPress = { [weak self] type, data in
+            guard let self else { return }
+            self.onUserActionPress(type: type, data: data)
+        }
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(self.reloadAll),
@@ -194,11 +198,6 @@ private extension ProfileViewController {
         view.addSubview(coverImage)
         view.addSubview(tableView)
         
-        header.onButtonPress = { [weak self] type, data in
-            guard let self else { return }
-            self.onUserActionPress(type: type, data: data)
-        }
-                
         NSLayoutConstraint.activate([
             self.coverImage.topAnchor.constraint(equalTo: self.view.topAnchor),
             self.coverImage.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),

--- a/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileHeader.swift
@@ -413,6 +413,7 @@ extension ProfileHeader {
             extraInfoStackView.removeFromSuperview()
             NSLayoutConstraint.deactivate(infoConstraints)
         }
+        self.extraInfoConstraints = nil
         
         // Set all fields
         if let fields = user.fields, !fields.isEmpty {


### PR DESCRIPTION
When switching accounts, ProfileHeader.onUserActionPress was nil (and so, tapping the field resulted in nothing happening). Now, onUserActionPress is set when ProfileHeader is created.

Also: clear self.extraInfoConstraints once it's associated data has been cleared.