### PR TITLE
MAM-3773-quote-post-carousels

### DIFF
--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -116,6 +116,7 @@ final class PostCardModel {
     enum MediaDisplayType {
         case singleImage
         case singleVideo
+        case singleGIF
         case carousel
         case none
         
@@ -123,6 +124,7 @@ final class PostCardModel {
             switch self {
             case .singleImage: return "image"
             case .singleVideo: return "video"
+            case .singleGIF: return "GIF"
             case .carousel: return "carousel"
             default: return nil
             }
@@ -381,8 +383,10 @@ final class PostCardModel {
             switch self.mediaAttachments.first?.type {
             case .image:
                 self.mediaDisplayType = .singleImage
-            case .gifv, .video:
+            case .video:
                 self.mediaDisplayType = .singleVideo
+            case .gifv:
+                self.mediaDisplayType = .singleGIF
             default:
                 // TODO: enable single media view for all media types when implementation is done (video, gifs, images and audio)
                 self.mediaDisplayType = .carousel

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
@@ -516,7 +516,7 @@ extension NewsFeedViewModel {
                     postCard.preloadQuotePost()
                 }
                 
-                if postCard.mediaDisplayType == .singleVideo {
+                if postCard.mediaDisplayType == .singleVideo || postCard.mediaDisplayType == .singleGIF {
                     postCard.preloadVideo()
                 }
                 
@@ -530,7 +530,7 @@ extension NewsFeedViewModel {
                     activity.postCard?.preloadQuotePost()
                 }
                 
-                if activity.postCard?.mediaDisplayType == .singleVideo {
+                if activity.postCard?.mediaDisplayType == .singleVideo || activity.postCard?.mediaDisplayType == .singleGIF {
                     activity.postCard?.preloadVideo()
                 }
                 

--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -592,7 +592,7 @@ extension ProfileViewModel {
                         card.preloadImages()
                     }
                     
-                    if card.mediaDisplayType == .singleVideo {
+                    if card.mediaDisplayType == .singleVideo || card.mediaDisplayType == .singleGIF {
                         card.preloadVideo()
                     }
                 }
@@ -608,7 +608,7 @@ extension ProfileViewModel {
                         card.preloadImages()
                     }
                     
-                    if card.mediaDisplayType == .singleVideo {
+                    if card.mediaDisplayType == .singleVideo || card.mediaDisplayType == .singleGIF {
                         card.preloadVideo()
                     }
                 }

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -222,7 +222,7 @@ final class ActivityCardCell: UITableViewCell {
     
     /// the cell will be displayed in the tableview
     public func willDisplay() {
-        if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
+        if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && [.singleVideo, .singleGIF].contains(postCard.mediaDisplayType) {
             if GlobalStruct.autoPlayVideos {
                 self.video?.play()
             }
@@ -238,7 +238,7 @@ final class ActivityCardCell: UITableViewCell {
     
     // the cell will end being displayed in the tableview
     public func didEndDisplay() {
-        if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo {
+        if let postCard = self.activityCard?.postCard, postCard.hasMediaAttachment && [.singleVideo, .singleGIF].contains(postCard.mediaDisplayType) {
             self.video?.pause()
         }
         
@@ -428,7 +428,7 @@ extension ActivityCardCell {
             }
             
             // Display single video/gif if needed
-            if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleVideo && !hideMedia {
+            if postCard.hasMediaAttachment && [.singleVideo, .singleGIF].contains(postCard.mediaDisplayType) && !hideMedia {
                 if self.video == nil {
                     self.video = PostCardVideo(variant: .thumbnail)
                     self.video!.translatesAutoresizingMaskIntoConstraints = false

--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -310,6 +310,7 @@ extension PostCardQuotePost {
             // Display post text
             if let postTextContent = quotePostCard.metaPostText, !postTextContent.original.isEmpty {
                 self.postTextLabel.configure(content: postTextContent)
+                self.postTextLabel.isHidden = false
             } else if [.small, .hidden].contains(self.mediaVariant) {
                 // If there's no post text, but a media attachment,
                 // set the post text to either:
@@ -319,11 +320,17 @@ extension PostCardQuotePost {
                     if let desc = quotePostCard.mediaAttachments.first?.description {
                         let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
                         self.postTextLabel.configure(content: content)
+                        self.postTextLabel.isHidden = false
                     } else {
                         let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type))", emojis: [:]))
                         self.postTextLabel.configure(content: content)
+                        self.postTextLabel.isHidden = false
                     }
+                } else {
+                    self.postTextLabel.isHidden = true
                 }
+            } else {
+                self.postTextLabel.isHidden = true
             }
             
             self.postTextLabel.isUserInteractionEnabled = false

--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -155,7 +155,7 @@ class PostCardQuotePost: UIView {
         mediaContainer.directionalLayoutMargins.leading = 12
         mediaContainer.directionalLayoutMargins.trailing = 12
         
-        self.postTextLabel.attributedText = nil
+        self.postTextLabel.reset()
         textAndSmallMediaStackView.removeArrangedSubview(self.postTextLabel)
         self.postTextLabel.removeFromSuperview()
         
@@ -315,7 +315,7 @@ extension PostCardQuotePost {
                 // set the post text to either:
                 //  - ([type])
                 //  - ([type] description: [meta description])
-                if let type = quotePostCard.mediaAttachments.first?.type.rawValue.capitalized  {
+                if let type = quotePostCard.mediaDisplayType.displayName?.capitalized  {
                     if let desc = quotePostCard.mediaAttachments.first?.description {
                         let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
                         self.postTextLabel.configure(content: content)
@@ -387,7 +387,7 @@ extension PostCardQuotePost {
             }
             
             // Display single video/gif if needed
-            if quotePostCard.hasMediaAttachment && quotePostCard.mediaDisplayType == .singleVideo {
+            if quotePostCard.hasMediaAttachment && [.singleVideo, .singleGIF].contains(quotePostCard.mediaDisplayType) {
                 if self.video == nil {
                     switch self.mediaVariant {
                     case .small:


### PR DESCRIPTION
Display gallery, stack, or no media in quote post, depending on Media Size setting.
Fix text labels when posts or quoted post has no post text but has some media ((image), (video), (carousel), (gif))

[MAM-3773 : Quote Post Carousels](https://linear.app/theblvd/issue/MAM-3773/quote-post-carousels)