### PR TITLE
MAM-3772-photo-carousel-no-text

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -404,6 +404,8 @@ final class PostCardCell: UITableViewCell {
         self.footer.onButtonPress = nil
         self.separatorInset = .zero
         
+        self.contentStackView.setCustomSpacing(self.contentStackView.spacing, after: self.header)
+        
         self.contentWarningButton.isHidden = true
         self.contentWarningButton.isUserInteractionEnabled = false
         NSLayoutConstraint.deactivate(self.contentWarningConstraints)
@@ -712,7 +714,6 @@ extension PostCardCell {
                     }
                 }
             }
-            
         }
         
         if self.cellVariant.hasMedia {
@@ -782,6 +783,10 @@ extension PostCardCell {
                     self.mediaGallery?.configure(postCard: postCard)
                     self.mediaGallery?.isHidden = false
                     self.mediaStack?.isHidden = true
+                    
+                    if !self.cellVariant.hasText {
+                        self.contentStackView.setCustomSpacing(24, after: self.header)
+                    }
                 }
                 
             } else {


### PR DESCRIPTION
Add additional top margin on the gallery when there's no post text. (to prevent the scroll view content to overlap with the profile pic)

[MAM-3772 : Photo carousel no-text](https://linear.app/theblvd/issue/MAM-3772/photo-carousel-no-text)