### PR TITLE
MAM-3778-capitalize-gif-label-in-smallhidden-media-mode

### DIFF
--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -129,6 +129,16 @@ final class PostCardModel {
             default: return nil
             }
         }
+        
+        var captializedDisplayName: String? {
+            switch self {
+            case .singleImage: return "Image"
+            case .singleVideo: return "Video"
+            case .singleGIF: return "GIF"
+            case .carousel: return "Carousel"
+            default: return nil
+            }
+        }
     }
     
     enum QuotePostStatus: Int, CaseIterable, Equatable {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -714,7 +714,7 @@ extension PostCardCell {
                 // set the post text to either:
                 //  - ([type])
                 //  - ([type] description: [meta description])
-                if let type = postCard.mediaDisplayType.displayName?.capitalized  {
+                if let type = postCard.mediaDisplayType.captializedDisplayName  {
                     if let desc = postCard.mediaAttachments.first?.description {
                         let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
                         self.postTextView.configure(content: content)

--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -316,7 +316,7 @@ extension PostCardQuotePost {
                 // set the post text to either:
                 //  - ([type])
                 //  - ([type] description: [meta description])
-                if let type = quotePostCard.mediaDisplayType.displayName?.capitalized  {
+                if let type = quotePostCard.mediaDisplayType.captializedDisplayName  {
                     if let desc = quotePostCard.mediaAttachments.first?.description {
                         let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
                         self.postTextLabel.configure(content: content)


### PR DESCRIPTION
[MAM-3778 : Capitalize GIF label in small/hidden media mode](https://linear.app/theblvd/issue/MAM-3778/capitalize-gif-label-in-smallhidden-media-mode)