### PR TITLE
MAM-3787-fix-profile-pagination-errors-after-user-sync

### DIFF
--- a/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewModel.swift
@@ -785,7 +785,7 @@ private extension ProfileViewModel {
         if let account = (acctData as? MastodonAcctData)?.account,
            account.fullAcct == self.user?.account?.fullAcct {
             // Override user with updated user account
-            let userCard = UserCardModel(account: account)
+            let userCard = UserCardModel(account: account, instanceName: self.user?.instanceName)
             let preSyncAccount = self.user?.preSyncAccount
             let cachedProfilePic = self.user?.decodedProfilePic
             
@@ -805,7 +805,7 @@ private extension ProfileViewModel {
         if let account = (acctData as? MastodonAcctData)?.account,
            account.fullAcct == self.user?.account?.fullAcct {
             // Override user with updated user account
-            let userCard = UserCardModel(account: account)
+            let userCard = UserCardModel(account: account, instanceName: self.user?.instanceName)
             let preSyncAccount = self.user?.preSyncAccount
             let cachedProfilePic = self.user?.decodedProfilePic
             
@@ -821,7 +821,7 @@ private extension ProfileViewModel {
         if let updatedfullAcct = notification.userInfo!["otherUserFullAcct"] as? String, let currentAccount = user?.account, updatedfullAcct == currentAccount.fullAcct {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                let userCard = UserCardModel(account: currentAccount)
+                let userCard = UserCardModel(account: currentAccount, instanceName: self.user?.instanceName)
                 if userCard.followStatus != .inProgress {
                     let preSyncAccount = self.user?.preSyncAccount
                     let cachedProfilePic = self.user?.decodedProfilePic


### PR DESCRIPTION
When visiting someone's profile we fetch the user object from its original instance and replace the user object (UserCardModel) in ProfileViewModel with it. Later, we recreated the user instead of mutating it to update the user but forgot to copy over the instanceName. This lead to a broken pagination on profile screen when the original user was from a different instance as the logged in instance. 

[MAM-3787 : Fix profile pagination errors after user sync](https://linear.app/theblvd/issue/MAM-3787/fix-profile-pagination-errors-after-user-sync)