### PR TITLE
MAM-3780-image-in-carousels-should-never-have-thumbnails-wider-than

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -10,7 +10,7 @@ import UIKit
 import SDWebImage
 import UnifiedBlurHash
 
-fileprivate let PostCardMediaGalleryHeight = 180.0
+fileprivate let PostCardMediaGalleryHeight =  min((UIScreen.main.bounds.width * 0.76) * (9.0/16.0), 260)
 
 final class PostCardMediaGallery: UIView {
 
@@ -81,6 +81,7 @@ extension PostCardMediaGallery {
     func prepareForReuse() {
         self.attachments = nil
         self.postCard = nil
+        self.scrollView.setContentOffset(.zero, animated: false)
         self.stackView.arrangedSubviews.forEach({
             self.stackView.removeArrangedSubview($0)
             $0.removeFromSuperview()


### PR DESCRIPTION
Make the carousel height variable based on the screen width, and max 260px

[MAM-3780 : Image in carousels should never have thumbnails wider than the content area.](https://linear.app/theblvd/issue/MAM-3780/image-in-carousels-should-never-have-thumbnails-wider-than-the-content)

Tested on iPhone SE, iPhone 15 Pro and Mac

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-23 at 15 10 43](https://github.com/TheBLVD/mammoth/assets/221925/c53e4841-85e9-4cd3-bda4-4b6407d33ff9)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-23 at 15 11 17](https://github.com/TheBLVD/mammoth/assets/221925/f32069ef-297c-444b-93b1-c2a1305d3eb6)
<img width="1553" alt="Screenshot 2024-01-23 at 15 15 28" src="https://github.com/TheBLVD/mammoth/assets/221925/e1d8857f-96f7-4583-b247-c6ba093ed47d">
