### PR TITLE
MAM-3771-jumpy-swipes-when-fullscreening-a-carousel

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -305,7 +305,9 @@ final class PostCardImage: UIView {
                 
                 var blurImage: UIImage? = nil
                 if let blurhash = attachment.blurhash, let currentMedia = self.media, attachment.url != currentMedia.url {
-                    blurImage = UnifiedImage(blurHash: blurhash, size: .init(width: 32, height: 32))
+                    let blurWidth = attachment.meta?.original?.width != nil ? attachment.meta!.original!.width! / 20 : 32
+                    let blurHeight = attachment.meta?.original?.height != nil ? attachment.meta!.original!.height! / 20 : 32
+                    blurImage = UnifiedImage(blurHash: blurhash, size: .init(width: blurWidth, height: blurHeight))
                 }
                 photo.underlyingImage = SDImageCache.shared.imageFromCache(forKey: attachment.url) ?? blurImage
                 return photo

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -303,13 +303,15 @@ final class PostCardImage: UIView {
                 let photo = SKPhoto.photoWithImageURL(attachment.url)
                 photo.shouldCachePhotoURLImage = false
                 
+                let imageFromCache = SDImageCache.shared.imageFromCache(forKey: attachment.url)
+                
                 var blurImage: UIImage? = nil
-                if let blurhash = attachment.blurhash, let currentMedia = self.media, attachment.url != currentMedia.url {
+                if let blurhash = attachment.blurhash, imageFromCache == nil, let currentMedia = self.media, attachment.url != currentMedia.url {
                     let blurWidth = attachment.meta?.original?.width != nil ? attachment.meta!.original!.width! / 20 : 32
                     let blurHeight = attachment.meta?.original?.height != nil ? attachment.meta!.original!.height! / 20 : 32
                     blurImage = UnifiedImage(blurHash: blurhash, size: .init(width: blurWidth, height: blurHeight))
                 }
-                photo.underlyingImage = SDImageCache.shared.imageFromCache(forKey: attachment.url) ?? blurImage
+                photo.underlyingImage = imageFromCache ?? blurImage
                 return photo
             } ?? [SKPhoto()]
             


### PR DESCRIPTION
- Attempt to decrease jumpy swipes by preloading images in the background
- Use a blurhash image placeholder if image is not yet preloaded

[MAM-3771 : Jumpy swipes when fullscreening a carousel.](https://linear.app/theblvd/issue/MAM-3771/jumpy-swipes-when-fullscreening-a-carousel)