### PR TITLE
MAM-3741-post-sync-logic-should-use-the-users-instance-not-mothsocial

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
@@ -631,7 +631,7 @@ extension NewsFeedViewModel {
         case .postCard(let postCard):
             guard !postCard.isSyncedWithOriginal else { return }
             do {
-                if let status = try await StatusService.fetchStatus(id: postCard.originalId, instanceName: postCard.originalInstanceName ?? GlobalHostServer()) {
+                if let status = try await StatusService.fetchStatus(id: postCard.originalId, instanceName: postCard.originalInstanceName ?? AccountsManager.shared.currentAccountClient.baseHost) {
                     guard !Task.isCancelled else { return }
 
                     let newPostCard = postCard.mergeInOriginalData(status: status)


### PR DESCRIPTION
[MAM-3741 : Post sync logic should use the user's instance, not moth.social](https://linear.app/theblvd/issue/MAM-3741/post-sync-logic-should-use-the-users-instance-not-mothsocial)