### PR TITLE
MAM-3791-tapping-on-post-details-for-uploaded-video-with-media-small

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -69,6 +69,7 @@ final class PostCardMediaGallery: UIView {
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard self.isHidden == false && self.attachments != nil else { return nil }
         let leadingInset = -86.0 // Inset needs to be >= leading inset from the edge of the cell to the gallery
         let trailingOffset = 800.0 // Offset needs to be >= trailing offset from the trailing edge of the gallery to the trailing edge of the cell
         let expendedBounds = CGRect.init(origin: self.bounds.insetBy(dx: leadingInset, dy: 0).origin,


### PR DESCRIPTION
[MAM-3791 : Tapping on Post Details for uploaded Video with "Media == Small" shows wrong Post](https://linear.app/theblvd/issue/MAM-3791/tapping-on-post-details-for-uploaded-video-with-media-==-small-shows)