### PR TITLE
MAM-3794-media-helper-text-in-small-mode-only-for-status

### DIFF
--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -394,7 +394,7 @@ extension ActivityCardCell {
                     self.postTextLabel.configure(content: content)
                     self.postTextLabel.isHidden = false
                     
-                } else if [.small, .hidden].contains(cellVariant?.mediaVariant) {
+                } else if [.small, .hidden].contains(cellVariant?.mediaVariant) && activity.type == .status {
                     // If there's no post text, but a media attachment,
                     // set the post text to either:
                     //  - ([type])


### PR DESCRIPTION
[MAM-3794 : Media helper text in small-mode only for status notifications](https://linear.app/theblvd/issue/MAM-3794/media-helper-text-in-small-mode-only-for-status-notifications)

It should only be saying (Carousel) in New Post notifications (in small-media mode)
![IMG_4A6D5BF29E08-1](https://github.com/TheBLVD/mammoth/assets/221925/ea0b6452-ed8a-46e3-ab39-06d35afd4b56)

