### PR TITLE
MAM-3806-crash-when-attaching-image-if-server-returns-status-code-500

### DIFF
--- a/Mammoth/Services/Backend/MastodonKit/ClientError.swift
+++ b/Mammoth/Services/Backend/MastodonKit/ClientError.swift
@@ -26,10 +26,18 @@ public enum ClientError: Error {
 extension ClientError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .malformedURL:
+            return "Malformed URL"
+        case .malformedJSON:
+            return "Malformed JSON"
+        case .invalidModel:
+            return "Invalid model"
+        case .genericError:
+            return "Unexpected error"
         case let .mastodonError(message):
             return message
-        default:
-            return self.localizedDescription
+        case let .networkError(statusCode):
+            return "Network error; status code \(statusCode)"
         }
     }
 }


### PR DESCRIPTION
Create specific error descriptions for specific error types.

In the crash case, it was a .networkError() that was calling self.localizedDescription, which in turn called ClientError.errorDescription.

I was able to simulate a network status code of 500, and see the alert as expected.