### PR TITLE
MAM-3670-activity-notifications-tapping-post-notification-doesnt-open

### DIFF
--- a/Mammoth/Screens/ActivityScreen/ActivityViewController.swift
+++ b/Mammoth/Screens/ActivityScreen/ActivityViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class ActivityViewController : UIViewController {
     
-    private let headerView: CarouselNavigationHeader = {
+    public let headerView: CarouselNavigationHeader = {
         let headerView = CarouselNavigationHeader(title: "Activity")
         headerView.translatesAutoresizingMaskIntoConstraints = false
         return headerView

--- a/Mammoth/Screens/MentionsScreen/MentionsViewController.swift
+++ b/Mammoth/Screens/MentionsScreen/MentionsViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class MentionsViewController : UIViewController {
     
-    private let headerView: CarouselNavigationHeader = {
+    public let headerView: CarouselNavigationHeader = {
         let headerView = CarouselNavigationHeader(title: "Mentions")
         headerView.translatesAutoresizingMaskIntoConstraints = false
         return headerView

--- a/Mammoth/Screens/TabBarViewController.swift
+++ b/Mammoth/Screens/TabBarViewController.swift
@@ -112,15 +112,28 @@ class TabBarViewController: AnimateTabController, UIGestureRecognizerDelegate, U
     
     @objc func goToActivityTab() {
         self.selectedIndex = GlobalStruct.tab3Index
-        // when the tab hasn't 'switched' to the activity view yet, as it doesn't act like the activity is loaded when there's no dispatch there
-        // it needs that time to do the switch tab
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            NotificationCenter.default.post(name: Notification.Name(rawValue: "fromPush"), object: self)
+        
+        if let activityVC = self.selectedViewController?.children.first as? ActivityViewController {
+            activityVC.carouselItemPressed(withIndex: 0)
+            activityVC.headerView.carousel.scrollTo(index: 0)
+            // Delay required to finish the carousel animation smoothly first
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                activityVC.jumpToNewest()
+            }
         }
     }
     
     @objc func goToMessagesTab() {
         self.selectedIndex = GlobalStruct.tab4Index
+        
+        if let mentionsVC = self.selectedViewController?.children.first as? MentionsViewController {
+            mentionsVC.carouselItemPressed(withIndex: 0)
+            mentionsVC.headerView.carousel.scrollTo(index: 0)
+            // Delay required to finish the carousel animation smoothly first
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                mentionsVC.jumpToNewest()
+            }
+        }
     }
     
     @objc func gotoS() {


### PR DESCRIPTION
Opens the Activity or Mentions tab, scrolls to top and fetches new content when tapping on the native push notification alert. 

[MAM-3670 : Activity Notifications: Tapping Post Notification doesn't open Post](https://linear.app/theblvd/issue/MAM-3670/activity-notifications-tapping-post-notification-doesnt-open-post)