### PR TITLE
MAM-3634-activity-notifications-notification-dots-not-clearing-after

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+DataSource.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+DataSource.swift
@@ -1123,6 +1123,10 @@ extension NewsFeedViewModel {
     
     // MARK: - Helpers
     
+    func isItemInSnapshot(_ item: NewsFeedListItem) -> Bool {
+        return self.getIndexPathForItem(item: item) != nil
+    }
+    
     // First item id in the feed
     func newestItemId(forType type: NewsFeedTypes) -> String? {
         guard let _ = self.snapshot.indexOfSection(.main) else { return nil }

--- a/Mammoth/Screens/HomeScreen/Views/UnreadIndicator.swift
+++ b/Mammoth/Screens/HomeScreen/Views/UnreadIndicator.swift
@@ -98,7 +98,12 @@ private extension UnreadIndicator {
 // MARK: - Configure
 extension UnreadIndicator {
     func configure(unreadCount: Int) {
-        guard self.unreadCount != unreadCount else { return }
+        guard self.unreadCount != unreadCount else {
+            if unreadCount == 0 && self.isEnabled {
+                self.isEnabled = false
+            }
+            return
+        }
         self.unreadCount = unreadCount
         self.setTitle(self.formatter.dividedByK(number: Double(unreadCount)), for: .normal)
         


### PR DESCRIPTION
Clearing the unread indicator and tab bar indicator in a more reliable way.

[MAM-3634 : Activity Notifications: Notification dots not clearing after checking](https://linear.app/theblvd/issue/MAM-3634/activity-notifications-notification-dots-not-clearing-after-checking)