### PR TITLE
MAM-3815-activity-notifications-navigate-to-target-post-when-pressing

### DIFF
--- a/Mammoth/AppDelegate.swift
+++ b/Mammoth/AppDelegate.swift
@@ -117,17 +117,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
             if let stat = (statuses.value) {
+                let postCard = stat.status != nil ? PostCardModel(status: stat.status!) : nil
                 DispatchQueue.main.async {
                     switch stat.type {
                     case .direct, .mention:
                         NotificationCenter.default.post(name: Notification.Name(rawValue: "showIndActivity2"), object: nil)
                         if alsoGoToTab {
-                            NotificationCenter.default.post(name: Notification.Name(rawValue: "goToMessagesTab"), object: self)
+                            NotificationCenter.default.post(name: Notification.Name(rawValue: "goToMessagesTab"), object: self, userInfo: postCard != nil ? ["postCard": postCard!] : nil)
                         }
                     default:
                         NotificationCenter.default.post(name: Notification.Name(rawValue: "showIndActivity"), object: nil)
                         if alsoGoToTab {
-                            NotificationCenter.default.post(name: Notification.Name(rawValue: "goToActivityTab"), object: self)
+                            NotificationCenter.default.post(name: Notification.Name(rawValue: "goToActivityTab"), object: self, userInfo: postCard != nil ? ["postCard": postCard!] : nil)
                         }
                     }
                     

--- a/Mammoth/Screens/TabBarViewController.swift
+++ b/Mammoth/Screens/TabBarViewController.swift
@@ -110,20 +110,37 @@ class TabBarViewController: AnimateTabController, UIGestureRecognizerDelegate, U
         self.present(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     
-    @objc func goToActivityTab() {
+    @objc func goToActivityTab(notification: Notification) {
         self.selectedIndex = GlobalStruct.tab3Index
         
         if let activityVC = self.selectedViewController?.children.first as? ActivityViewController {
             activityVC.carouselItemPressed(withIndex: 0)
             activityVC.headerView.carousel.scrollTo(index: 0)
+            
             // Delay required to finish the carousel animation smoothly first
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                 activityVC.jumpToNewest()
             }
+            
+            if let navController = self.selectedViewController as? UINavigationController {
+                navController.popToRootViewController(animated: true)
+            }
+            
+            // Navigate to the target post if there's one included in the notification
+            if let postCard = notification.userInfo?["postCard"] as? PostCardModel {
+                if !postCard.isDeleted && !postCard.isMuted && !postCard.isBlocked {
+                    let vc = DetailViewController(post: postCard)
+                    if vc.isBeingPresented {} else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            (self.selectedViewController as? UINavigationController)?.pushViewController(vc, animated: true)
+                        }
+                    }
+                }
+            }
         }
     }
     
-    @objc func goToMessagesTab() {
+    @objc func goToMessagesTab(notification: Notification) {
         self.selectedIndex = GlobalStruct.tab4Index
         
         if let mentionsVC = self.selectedViewController?.children.first as? MentionsViewController {
@@ -132,6 +149,22 @@ class TabBarViewController: AnimateTabController, UIGestureRecognizerDelegate, U
             // Delay required to finish the carousel animation smoothly first
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                 mentionsVC.jumpToNewest()
+            }
+            
+            if let navController = self.selectedViewController as? UINavigationController {
+                navController.popToRootViewController(animated: true)
+            }
+            
+            // Navigate to the target post if there's one included in the notification
+            if let postCard = notification.userInfo?["postCard"] as? PostCardModel {
+                if !postCard.isDeleted && !postCard.isMuted && !postCard.isBlocked {
+                    let vc = DetailViewController(post: postCard)
+                    if vc.isBeingPresented {} else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            (self.selectedViewController as? UINavigationController)?.pushViewController(vc, animated: true)
+                        }
+                    }
+                }
             }
         }
     }

--- a/Mammoth/Screens/iPad/ColumnViewController.swift
+++ b/Mammoth/Screens/iPad/ColumnViewController.swift
@@ -42,6 +42,9 @@ class ColumnViewController: UIViewController {
     
     required init() {
         super.init(nibName: nil, bundle: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.goToActivityTab), name: NSNotification.Name(rawValue: "goToActivityTab"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.goToMessagesTab), name: NSNotification.Name(rawValue: "goToMessagesTab"), object: nil)
     }
     
     private func setupUI() {
@@ -71,6 +74,7 @@ class ColumnViewController: UIViewController {
         // Side column view
         auxColumnPlaceholderView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(auxColumnPlaceholderView)
+        
     }
     
     required init?(coder: NSCoder) {
@@ -122,6 +126,65 @@ class ColumnViewController: UIViewController {
             previousAuxColumnVC?.willMove(toParent: nil)
             previousAuxColumnVC?.view.removeFromSuperview()
             previousAuxColumnVC?.removeFromParent()
+        }
+    }
+    
+    @objc func goToActivityTab(notification: Notification) {
+        self.sidebarViewController.barSingleTap(didSelect: 2)
+        
+        if let activityVC = self.mainColumnNavVC?.children.first as? ActivityViewController {
+            activityVC.carouselItemPressed(withIndex: 0)
+            activityVC.headerView.carousel.scrollTo(index: 0)
+            
+            // Delay required to finish the carousel animation smoothly first
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                activityVC.jumpToNewest()
+            }
+            
+            if let navController = self.mainColumnNavVC {
+                navController.popToRootViewController(animated: true)
+            }
+            
+            // Navigate to the target post if there's one included in the notification
+            if let postCard = notification.userInfo?["postCard"] as? PostCardModel {
+                if !postCard.isDeleted && !postCard.isMuted && !postCard.isBlocked {
+                    let vc = DetailViewController(post: postCard)
+                    if vc.isBeingPresented {} else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            self.mainColumnNavVC?.pushViewController(vc, animated: true)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    @objc func goToMessagesTab(notification: Notification) {
+        self.sidebarViewController.barSingleTap(didSelect: 3)
+        
+        if let mentionsVC = self.mainColumnNavVC?.children.first as? MentionsViewController {
+            mentionsVC.carouselItemPressed(withIndex: 0)
+            mentionsVC.headerView.carousel.scrollTo(index: 0)
+            // Delay required to finish the carousel animation smoothly first
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                mentionsVC.jumpToNewest()
+            }
+            
+            if let navController = self.mainColumnNavVC {
+                navController.popToRootViewController(animated: true)
+            }
+            
+            // Navigate to the target post if there's one included in the notification
+            if let postCard = notification.userInfo?["postCard"] as? PostCardModel {
+                if !postCard.isDeleted && !postCard.isMuted && !postCard.isBlocked {
+                    let vc = DetailViewController(post: postCard)
+                    if vc.isBeingPresented {} else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            self.mainColumnNavVC?.pushViewController(vc, animated: true)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/Mammoth/Screens/iPad/SidebarViewController.swift
+++ b/Mammoth/Screens/iPad/SidebarViewController.swift
@@ -435,7 +435,7 @@ extension SidebarViewController: Jumpable {
             }
         }
         
-        let itemToFetch = index + 1
+        self.collectionView.selectItem(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .top)
     }
 
     func viewControllerAtIndex(_ index: Int) -> UIViewController? {


### PR DESCRIPTION
[MAM-3815 : Activity Notifications: Navigate to target post when pressing notification](https://linear.app/theblvd/issue/MAM-3815/activity-notifications-navigate-to-target-post-when-pressing)