### PR TITLE
MAM-3824-carousel-stack-layout-issue

### DIFF
--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -238,6 +238,19 @@ final class ActivityCardCell: UITableViewCell {
         
         self.header.stopTimeUpdates()
     }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        if let mediaGallery = self.mediaGallery,
+           self.activityCard?.postCard?.mediaDisplayType == .carousel,
+            mediaGallery.isHidden == false,
+            mediaGallery.alpha == 1 {
+            let convertedPoint = mediaGallery.convert(point, from: self)
+            return mediaGallery.hitTest(convertedPoint, with: event) ?? hitView
+        }
+        
+        return hitView
+    }
 }
 
 // MARK: - Setup UI

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -434,12 +434,16 @@ final class PostCardCell: UITableViewCell {
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if let mediaGallery = self.mediaGallery, self.postCard?.mediaDisplayType == .carousel {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        if let mediaGallery = self.mediaGallery,
+            self.postCard?.mediaDisplayType == .carousel,
+            mediaGallery.isHidden == false,
+            mediaGallery.alpha == 1 {
             let convertedPoint = mediaGallery.convert(point, from: self)
-            return self.mediaGallery?.hitTest(convertedPoint, with: event) ?? super.hitTest(point, with: event)
+            return mediaGallery.hitTest(convertedPoint, with: event) ?? hitView
         }
         
-        return super.hitTest(point, with: event)
+        return hitView
     }
 }
 
@@ -855,6 +859,13 @@ extension PostCardCell {
             deletedWarningButton.setTitle("Muted author", for: .normal)
         }
         
+        // Hide media gallery (carousel) if covered with content warning / deleted overlay
+        if self.contentWarningButton.isHidden == false || self.deletedWarningButton.isHidden == false {
+            self.mediaGallery?.alpha = 0
+        } else {
+            self.mediaGallery?.alpha = 1
+        }
+        
         self.footer.configure(postCard: postCard, includeMetrics: false)
         self.footer.onButtonPress = onButtonPress
         
@@ -1117,6 +1128,7 @@ extension PostCardCell {
         self.contentWarningButton.isUserInteractionEnabled = false
         GlobalStruct.allCW.append(self.postCard?.id ?? "")
         self.postCard?.filterType = .none
+        self.mediaGallery?.alpha = 1
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -24,6 +24,8 @@ final class PostCardMediaGallery: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.clipsToBounds = false
         view.layoutMargins = .zero
+        view.isDirectionalLockEnabled = true
+        view.delaysContentTouches = false
         view.showsVerticalScrollIndicator = false
         view.showsHorizontalScrollIndicator = false
         return view
@@ -69,7 +71,7 @@ final class PostCardMediaGallery: UIView {
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard self.isHidden == false && self.attachments != nil else { return nil }
+        guard self.isHidden == false, self.alpha == 1, self.attachments != nil else { return nil }
         let leadingInset = -86.0 // Inset needs to be >= leading inset from the edge of the cell to the gallery
         let trailingOffset = 800.0 // Offset needs to be >= trailing offset from the trailing edge of the gallery to the trailing edge of the cell
         let expendedBounds = CGRect.init(origin: self.bounds.insetBy(dx: leadingInset, dy: 0).origin,
@@ -86,15 +88,7 @@ final class PostCardMediaGallery: UIView {
 }
 
 extension PostCardMediaGallery {
-    func prepareForReuse() {
-        self.attachments = nil
-        self.postCard = nil
-        self.scrollView.setContentOffset(.zero, animated: false)
-        self.stackView.arrangedSubviews.forEach({
-            self.stackView.removeArrangedSubview($0)
-            $0.removeFromSuperview()
-        })
-    }
+    func prepareForReuse() {}
     
     public func configure(postCard: PostCardModel) {
         let shouldUpdate = self.attachments == nil || postCard.mediaAttachments != self.attachments!
@@ -102,6 +96,12 @@ extension PostCardMediaGallery {
         self.postCard = postCard
         
         if shouldUpdate {
+            self.scrollView.setContentOffset(.zero, animated: false)
+            self.stackView.arrangedSubviews.forEach({
+                self.stackView.removeArrangedSubview($0)
+                $0.removeFromSuperview()
+            })
+                
             self.attachments?.forEach({ media in
                 if media.type == .image {
                     let image = PostCardImage(inGallery: true)


### PR DESCRIPTION
- hide the gallery carousel if there's content warning / content deleted overlay
- fix an issue where the hitTest was called for unrelated cells causing unresponsive and unpredictable behavior

[MAM-3824 : carousel stack layout issue](https://linear.app/theblvd/issue/MAM-3824/carousel-stack-layout-issue)