### PR TITLE
MAM-3829-switching-profiles-from-compose-screen-doesnt-change-the

### DIFF
--- a/Mammoth/Screens/Composer/EmoticonPickerViewController.swift
+++ b/Mammoth/Screens/Composer/EmoticonPickerViewController.swift
@@ -17,6 +17,17 @@ class EmoticonPickerViewController: UIViewController, UICollectionViewDelegate, 
     var doneOnce: Bool = false
     var engineNeedsStart = true
     
+    public let emoticons: [Emoji]?
+    
+    init(emoticons: [Emoji]?) {
+        self.emoticons = emoticons
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     @objc func rotated() {
         self.collectionView.reloadData()
     }
@@ -152,7 +163,7 @@ class EmoticonPickerViewController: UIViewController, UICollectionViewDelegate, 
     
     //MARK: CollectionView
     func allEmoticons() -> [Emoji] {
-         return (AccountsManager.shared.currentAccount as? MastodonAcctData)?.emoticons ?? []
+        return self.emoticons ?? []
     }
 
     

--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -1841,7 +1841,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
     @objc func customEmojiTapped() {
-        let vc = EmoticonPickerViewController()
+        let vc = EmoticonPickerViewController(emoticons: (self.currentAcct as? MastodonAcctData)?.emoticons)
         self.present(UINavigationController(rootViewController: vc), animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Use the custom emojis of the server of the current account in the composer, instead of the emojis of the current account in the rest of the app.

[MAM-3829 : Switching profiles from compose screen doesn't change the custom emoji picker.](https://linear.app/theblvd/issue/MAM-3829/switching-profiles-from-compose-screen-doesnt-change-the-custom-emoji)