### PR TITLE
MAM-3834-unsubscribe-subscribe-blocking-client

### DIFF
--- a/Mammoth/Managers/AccountsManager/AccountsManager.swift
+++ b/Mammoth/Managers/AccountsManager/AccountsManager.swift
@@ -493,6 +493,40 @@ extension AccountsManager {
             }
         }
     }
+    
+    public func updateCurrentAccountForYou(_ forYouAccount: ForYouAccount, writeToServer: Bool = true) {
+        if let account = self.currentAccount,
+           let acctHandler = acctHandlerForAcctData(account) {
+            Task {
+                // Compute the new updatedAccount with updated forYouInfo
+                var updatedAccount: any AcctDataType = account
+                if writeToServer {
+                    if let updatedAccountFromNetwork = await acctHandler.setForYouType(acctData: account, forYouInfo: forYouAccount.forYou) {
+                        updatedAccount = updatedAccountFromNetwork
+                    }
+                } else {
+                    if var modifiedAcct = updatedAccount as? MastodonAcctData {
+                        modifiedAcct.forYou = forYouAccount
+                        updatedAccount = modifiedAcct
+                    }
+                }
+                // The currentAccount may have changed while the network call was ongoing
+                // (seen in the onboarding case). For that reason, re-create an
+                // updated version of the current account now.
+                let currentAccount = self.currentAccount as! MastodonAcctData
+                let updatedCurrentAccount = MastodonAcctData(account: currentAccount.account, instanceData: currentAccount.instanceData, client: currentAccount.client, defaultPostVisibility: currentAccount.defaultPostVisibility, defaultPostingLanguage: currentAccount.defaultPostingLanguage, emoticons: currentAccount.emoticons, forYou: (updatedAccount as! MastodonAcctData).forYou, uniqueID: currentAccount.uniqueID)
+
+                // Store the updated settings to the account on disk
+                if var updatedAcctData = account as? MastodonAcctData {
+                    log.debug("writing back forYou data for \(updatedAcctData.remoteFullOriginalAcct)")
+                    updatedAcctData.forYou = (updatedAccount as? MastodonAcctData)!.forYou
+                    updateAccount(updatedAcctData)
+                }
+                
+                acctHandler.notifyAboutAccountUpdates(oldAcctData: account, newAcctData: updatedCurrentAccount)
+            }
+        }
+    }
 
     
     public func updateCurrentAccountForYou(_ forYouInfo: ForYouType, writeToServer: Bool = true) {

--- a/Mammoth/Managers/ChannelManager.swift
+++ b/Mammoth/Managers/ChannelManager.swift
@@ -184,7 +184,7 @@ extension ChannelManager {
                             NotificationCenter.default.post(name: ToastNotificationManager.toast.subscribed, object: nil)
                         }
                     }
-                    AccountsManager.shared.updateCurrentAccountForYou(forYouInfo.forYou)
+                    AccountsManager.shared.updateCurrentAccountForYou(forYouInfo, writeToServer: false)
                 } catch {
                     log.error("\(error)")
                 }
@@ -214,7 +214,7 @@ extension ChannelManager {
                         NotificationCenter.default.post(name: ToastNotificationManager.toast.unsubscribed, object: nil)
                     }
                 }
-                AccountsManager.shared.updateCurrentAccountForYou(result.forYou)
+                AccountsManager.shared.updateCurrentAccountForYou(result, writeToServer: false)
             }
         }
     }


### PR DESCRIPTION
Don't call `/for_you/me` right after subscribe/unsubscribe of smart lists, but use the subscribe/unsubscribe network call result to update the local user. 

[MAM-3834 : Unsubscribe / Subscribe blocking (client)](https://linear.app/theblvd/issue/MAM-3834/unsubscribe-subscribe-blocking-client)