### PR TITLE
MAM-3835-unable-to-create-new-mothsocial-account-if-language-set-to-b…

### DIFF
--- a/Mammoth/Screens/Registration/SignUpViewController.swift
+++ b/Mammoth/Screens/Registration/SignUpViewController.swift
@@ -148,7 +148,7 @@ class SignUpViewController: UIViewController, UITextFieldDelegate {
     
     func registerAccount(_ newInstance: InstanceData) {
         // test account stuff
-        let request = Accounts.registerAccount(username: self.usernameText, email: self.emailText, password: self.passwordText, agreement: true, locale: Locale.current.languageCode ?? "en")
+        let request = Accounts.registerAccount(username: self.usernameText, email: self.emailText, password: self.passwordText, agreement: true, locale: "en")
         GlobalStruct.newClient.run(request) { (statuses) in
             if let error = statuses.error {
                 DispatchQueue.main.async {


### PR DESCRIPTION
…razilian

The Mastodon server will return an error it doesn't have an exact match for the localization language being requested in the signup flow. The app requests "pt" in this case, but the server only has "pt-BR" and "pt-PT"

For now, request that the confirmation email be sent in English, and longer term, look at doing a re-request if we get this error. (would need to update the error handling code as well).