### PR TITLE
MAM-3465--feature-request]-higher-contrast-of-text-in-dark-theme

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -630,6 +630,7 @@
 		BF93257E2A4262C80034CAE7 /* ExtendedTouchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF93257D2A4262C80034CAE7 /* ExtendedTouchView.swift */; };
 		BF9325802A451B280034CAE7 /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF93257F2A451B280034CAE7 /* ProfileImage.swift */; };
 		BF96F7DD2AA117E0004020A4 /* SearchHostHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF96F7DC2AA117E0004020A4 /* SearchHostHeaderView.swift */; };
+		BFA520F02B474C28007C7A24 /* ThemeContrastTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA520EF2B474C28007C7A24 /* ThemeContrastTrait.swift */; };
 		BFA71B4F2AB22D4B001D1EC1 /* InstancesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA71B4E2AB22D4B001D1EC1 /* InstancesViewController.swift */; };
 		BFA71B512AB22D58001D1EC1 /* InstancesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA71B502AB22D58001D1EC1 /* InstancesViewModel.swift */; };
 		BFA71B532AB23547001D1EC1 /* InstanceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA71B522AB23547001D1EC1 /* InstanceCell.swift */; };
@@ -1473,6 +1474,7 @@
 		BF93257D2A4262C80034CAE7 /* ExtendedTouchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedTouchView.swift; sourceTree = "<group>"; };
 		BF93257F2A451B280034CAE7 /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		BF96F7DC2AA117E0004020A4 /* SearchHostHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHostHeaderView.swift; sourceTree = "<group>"; };
+		BFA520EF2B474C28007C7A24 /* ThemeContrastTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeContrastTrait.swift; sourceTree = "<group>"; };
 		BFA71B4E2AB22D4B001D1EC1 /* InstancesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstancesViewController.swift; sourceTree = "<group>"; };
 		BFA71B502AB22D58001D1EC1 /* InstancesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstancesViewModel.swift; sourceTree = "<group>"; };
 		BFA71B522AB23547001D1EC1 /* InstanceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceCell.swift; sourceTree = "<group>"; };
@@ -1798,6 +1800,7 @@
 			isa = PBXGroup;
 			children = (
 				5339943D2914214A00560F83 /* SettingsViewController.swift */,
+				BFA520EF2B474C28007C7A24 /* ThemeContrastTrait.swift */,
 				533994362914214A00560F83 /* AccountsSettingsViewController.swift */,
 				5339940D2914214A00560F83 /* IconSettingsViewController.swift */,
 				5339943C2914214A00560F83 /* AppearanceSettingsViewController.swift */,
@@ -3695,6 +3698,7 @@
 				5339963E2914227A00560F83 /* MultilineTextField.swift in Sources */,
 				5339947F2914214A00560F83 /* IconSettingsViewController.swift in Sources */,
 				533994C72914214A00560F83 /* ProfileNoteViewController.swift in Sources */,
+				BFA520F02B474C28007C7A24 /* ThemeContrastTrait.swift in Sources */,
 				BF0C9DEE299946C50046D072 /* Log.swift in Sources */,
 				BF44B2D62B2D29F400442F61 /* PostLanguages.swift in Sources */,
 				C3C22E762A39C1F100C7CB0A /* ProfileCoverImage.swift in Sources */,

--- a/Mammoth/AppDelegate.swift
+++ b/Mammoth/AppDelegate.swift
@@ -159,6 +159,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         GlobalStruct.padColWidth = UserDefaults.standard.value(forKey: "padColWidth") as? Int ?? 412
         
         GlobalStruct.overrideTheme = UserDefaults.standard.value(forKey: "overrideTheme") as? Int ?? 0
+        GlobalStruct.overrideThemeHighContrast = UserDefaults.standard.value(forKey: "overrideThemeHighContrast") as? Bool ?? false
         GlobalStruct.customTextSize = UserDefaults.standard.value(forKey: "customTextSize") as? CGFloat ?? 0
         GlobalStruct.customLineSize = UserDefaults.standard.value(forKey: "customLineSize") as? CGFloat ?? 0
         GlobalStruct.timeStampStyle = UserDefaults.standard.value(forKey: "timeStampStyle") as? Int ?? 0

--- a/Mammoth/Assets/Assets.xcassets/HCColors/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCActive Inverted.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCActive Inverted.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEE",
+          "green" : "0xEE",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCActive.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCActive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x13",
+          "red" : "0x13"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEC",
+          "green" : "0xEC",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCBackground.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF7",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x09",
+          "red" : "0x09"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY High.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY High.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0xC9",
+          "green" : "0xC9",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x3F",
+          "green" : "0x3F",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY Med.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY Med.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.700",
+          "blue" : "0x2C",
+          "green" : "0x2C",
+          "red" : "0x2C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY Neut.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCBlurred OVRLY Neut.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0xF4",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0x09",
+          "green" : "0x09",
+          "red" : "0x09"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCDestructive Light.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCDestructive Light.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0x77",
+          "red" : "0xDD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0x77",
+          "red" : "0xDD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCDestructive.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCDestructive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x39",
+          "green" : "0x39",
+          "red" : "0xD7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x39",
+          "green" : "0x39",
+          "red" : "0xD7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCDisplay Names.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCDisplay Names.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x13",
+          "red" : "0x13"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEC",
+          "green" : "0xEC",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCFeint Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCFeint Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1F",
+          "green" : "0x1F",
+          "red" : "0x1F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC4",
+          "green" : "0xC4",
+          "red" : "0xC4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCFollow Button BG.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCFollow Button BG.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCGold.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCGold.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x56",
+          "green" : "0xA8",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x56",
+          "green" : "0xA8",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCHigh Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCHigh Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x08",
+          "green" : "0x08",
+          "red" : "0x08"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCImage Overlay.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCImage Overlay.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0xF4",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0x15",
+          "green" : "0x15",
+          "red" : "0x15"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCInactive.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCInactive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0x47",
+          "red" : "0x47"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x86",
+          "green" : "0x86",
+          "red" : "0x86"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCLink Text Inactive.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCLink Text Inactive.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0x7B",
+          "red" : "0x7B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0x7B",
+          "red" : "0x7B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCLink Text.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCLink Text.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0D",
+          "green" : "0x0D",
+          "red" : "0x0D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCMedium Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCMedium Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x23",
+          "green" : "0x23",
+          "red" : "0x23"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE8",
+          "green" : "0xE8",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Med Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Med Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCE",
+          "green" : "0xCE",
+          "red" : "0xCE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x2F",
+          "red" : "0x2F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Soft Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Soft Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCOutlines.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCOutlines.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xBC",
+          "red" : "0xBC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0x45",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCSoft Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCSoft Contrast.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3E",
+          "green" : "0x3E",
+          "red" : "0x3E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCF",
+          "green" : "0xCF",
+          "red" : "0xCF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCStatus Bar.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCStatus Bar.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mammoth/Models/GlobalStruct.swift
+++ b/Mammoth/Models/GlobalStruct.swift
@@ -106,6 +106,7 @@ public struct GlobalStruct {
     
     // app settings
     static var overrideTheme: Int = 0
+    static var overrideThemeHighContrast = false
     static var soundsEnabled: Bool = true
     static var hapticsEnabled: Bool = true
     static var actionAnimations: Bool = true

--- a/Mammoth/SceneDelegate.swift
+++ b/Mammoth/SceneDelegate.swift
@@ -233,11 +233,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             window?.overrideUserInterfaceStyle = .unspecified
         } else if GlobalStruct.overrideTheme == 1 {
             UIApplication.shared.statusBarStyle = .darkContent
-            window?.overrideUserInterfaceStyle = .light
+            self.window?.overrideUserInterfaceStyle = .light
         } else {
             UIApplication.shared.statusBarStyle = .lightContent
-            window?.overrideUserInterfaceStyle = .dark
+            self.window?.overrideUserInterfaceStyle = .dark
         }
+        
+        if #available(iOS 17.0, *) {
+            var themeContrast: ThemeContrast
+            if GlobalStruct.overrideThemeHighContrast {
+                themeContrast = ThemeContrast.highContrast
+            } else {
+                themeContrast = ThemeContrast.standard
+            }
+            
+            self.window?.windowScene?.traitOverrides.themeContrast = themeContrast
+        }
+
     }
     
     func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {

--- a/Mammoth/Screens/ChatMessageViewController.swift
+++ b/Mammoth/Screens/ChatMessageViewController.swift
@@ -103,8 +103,9 @@ class ChatMessagesViewController: MessagesViewController, MessagesDataSource, Me
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
        if #available(iOS 13.0, *) {
-           if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+           if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                messagesCollectionView.reloadData()
                scrollDownButton.backgroundColor = .custom.quoteTint
                scrollDownButton.layer.borderColor = UIColor.systemGray3.cgColor

--- a/Mammoth/Screens/DetailScreen/DetailViewController.swift
+++ b/Mammoth/Screens/DetailScreen/DetailViewController.swift
@@ -423,7 +423,7 @@ internal extension DetailViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }

--- a/Mammoth/Screens/DetailScreen/Views/ScrollUpIndicator.swift
+++ b/Mammoth/Screens/DetailScreen/Views/ScrollUpIndicator.swift
@@ -112,7 +112,7 @@ internal extension ScrollUpIndicator {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.blurEffectView.layer.borderColor = UIColor.systemGray4.cgColor
             }
          }

--- a/Mammoth/Screens/DiscoveryScreen/DiscoveryViewController.swift
+++ b/Mammoth/Screens/DiscoveryScreen/DiscoveryViewController.swift
@@ -98,8 +98,19 @@ class DiscoveryViewController: UIViewController {
     }
     
     @objc private func onThemeChange() {
+        self.tableView.backgroundColor = .custom.background
         self.tableView.reloadData()
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+       super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                self.onThemeChange()
+            }
+        }
+   }
+
 }
 
 // MARK: UI Setup

--- a/Mammoth/Screens/DiscoveryScreen/InstancesViewController.swift
+++ b/Mammoth/Screens/DiscoveryScreen/InstancesViewController.swift
@@ -65,6 +65,15 @@ class InstancesViewController: UIViewController, UITableViewDataSourcePrefetchin
                                                object: nil)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+       super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                tableView.backgroundColor = .custom.background
+            }
+        }
+   }
+
 }
 
 // MARK: UI Setup

--- a/Mammoth/Screens/DiscoveryScreen/Views/SectionHeader.swift
+++ b/Mammoth/Screens/DiscoveryScreen/Views/SectionHeader.swift
@@ -87,3 +87,17 @@ extension SectionHeader {
     }
 }
 
+// MARK: - Appearance changes
+internal extension SectionHeader {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.backgroundColor = .custom.OVRLYSoftContrast
+                 label.textColor = .custom.mediumContrast
+                 button.setTitleColor(.custom.softContrast, for: .normal)
+             }
+         }
+    }
+}

--- a/Mammoth/Screens/HomeScreen/FeedEditorViewController.swift
+++ b/Mammoth/Screens/HomeScreen/FeedEditorViewController.swift
@@ -268,7 +268,7 @@ internal extension FeedEditorViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }

--- a/Mammoth/Screens/HomeScreen/HomeViewController.swift
+++ b/Mammoth/Screens/HomeScreen/HomeViewController.swift
@@ -427,7 +427,7 @@ internal extension HomeViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -1012,8 +1012,9 @@ internal extension NewsFeedViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
+                 onThemeChange()
              }
          }
     }

--- a/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
+++ b/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
@@ -111,6 +111,14 @@ class Carousel: UIView {
             stackView.addArrangedSubview(contextButton)
         }
     }
+    
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Set everything that is using a custom color
+        collectionView.reloadData()
+    }
+
         
     override var intrinsicContentSize: CGSize {
         return UIView.layoutFittingExpandedSize

--- a/Mammoth/Screens/HomeScreen/Views/LatestPill.swift
+++ b/Mammoth/Screens/HomeScreen/Views/LatestPill.swift
@@ -404,7 +404,7 @@ internal extension LatestPill {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.picBorder1.borderColor = UIColor.custom.quoteTint.cgColor
                  self.picBorder1.backgroundColor = UIColor.custom.quoteTint.cgColor
                  

--- a/Mammoth/Screens/HomeScreen/Views/UnreadIndicator.swift
+++ b/Mammoth/Screens/HomeScreen/Views/UnreadIndicator.swift
@@ -121,7 +121,7 @@ internal extension UnreadIndicator {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.blurEffectView.layer.borderColor = UIColor.systemGray4.cgColor
                  self.setTitleColor(.label, for: .normal)
             }

--- a/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
+++ b/Mammoth/Screens/ProfileScreen/ProfileViewController.swift
@@ -250,7 +250,7 @@ internal extension ProfileViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.titleView.onThemeChange()
                  self.header.onThemeChange()
                  self.coverImage.onThemeChange()

--- a/Mammoth/Screens/ProfileScreen/Views/ProfileViewSettingsButton.swift
+++ b/Mammoth/Screens/ProfileScreen/Views/ProfileViewSettingsButton.swift
@@ -120,7 +120,7 @@ internal extension ProfileViewSettingsButton {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
                  self.menu = self.createContextMenu()
             }

--- a/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
@@ -54,6 +54,10 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
         return status
     }()
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     override func viewDidLayoutSubviews() {
         self.tableView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width, height: self.view.bounds.height)
         
@@ -119,6 +123,13 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 self.extendedLayoutIncludesOpaqueBars = false
             }
         }
+    }
+
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        log.error("traitCollectionDidChange!")
+        super.traitCollectionDidChange(previousTraitCollection)
+        self.reloadAll()
     }
 
     override func viewDidLoad() {
@@ -255,17 +266,19 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 cell.imageView?.image = settingsFontAwesomeImage("\u{f1fc}")
                 switch GlobalStruct.overrideTheme {
                 case 1:
-                    cell.detailTextLabel?.text = "Light"
+                    cell.detailTextLabel?.text = GlobalStruct.overrideThemeHighContrast ? "Light (high contrast)" : "Light"
                 case 2:
-                    cell.detailTextLabel?.text = "Dark"
+                    cell.detailTextLabel?.text = GlobalStruct.overrideThemeHighContrast ? "Dark (high contrast)" : "Dark"
                 default:
                     cell.detailTextLabel?.text = "System"
                 }
 
                 var gestureActions: [UIAction] = []
                 let op1 = UIAction(title: "System", image: settingsFontAwesomeImage("\u{f042}"), identifier: nil) { action in
+                    GlobalStruct.overrideThemeHighContrast = false
                     GlobalStruct.overrideTheme = 0
-                    UserDefaults.standard.set(0, forKey: "overrideTheme")
+                    UserDefaults.standard.set(GlobalStruct.overrideThemeHighContrast, forKey: "overrideThemeHighContrast")
+                    UserDefaults.standard.set(GlobalStruct.overrideTheme, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.systemDefault)
                     NotificationCenter.default.post(name: Notification.Name(rawValue: "overrideTheme"), object: nil)
                     self.tableView.reloadRows(at: [indexPath], with: .none)
@@ -276,29 +289,64 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 }
                 gestureActions.append(op1)
                 let op2 = UIAction(title: "Light", image: settingsFontAwesomeImage("\u{e0c9}"), identifier: nil) { action in
+                    GlobalStruct.overrideThemeHighContrast = false
                     GlobalStruct.overrideTheme = 1
-                    UserDefaults.standard.set(1, forKey: "overrideTheme")
+                    UserDefaults.standard.set(GlobalStruct.overrideThemeHighContrast, forKey: "overrideThemeHighContrast")
+                    UserDefaults.standard.set(GlobalStruct.overrideTheme, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.light)
                     NotificationCenter.default.post(name: Notification.Name(rawValue: "overrideTheme"), object: nil)
                     self.tableView.reloadRows(at: [indexPath], with: .none)
 
                 }
-                if GlobalStruct.overrideTheme == 1 {
+                if GlobalStruct.overrideTheme == 1 && GlobalStruct.overrideThemeHighContrast == false {
                     op2.state = .on
                 }
                 gestureActions.append(op2)
                 let op3 = UIAction(title: "Dark", image: settingsFontAwesomeImage("\u{f186}"), identifier: nil) { action in
+                    GlobalStruct.overrideThemeHighContrast = false
                     GlobalStruct.overrideTheme = 2
-                    UserDefaults.standard.set(2, forKey: "overrideTheme")
+                    UserDefaults.standard.set(GlobalStruct.overrideThemeHighContrast, forKey: "overrideThemeHighContrast")
+                    UserDefaults.standard.set(GlobalStruct.overrideTheme, forKey: "overrideTheme")
                     FontAwesome.setColorTheme(theme: ColorTheme.dark)
                     NotificationCenter.default.post(name: Notification.Name(rawValue: "overrideTheme"), object: nil)
                     self.tableView.reloadRows(at: [indexPath], with: .none)
 
                 }
-                if GlobalStruct.overrideTheme == 2 {
+                if GlobalStruct.overrideTheme == 2 && GlobalStruct.overrideThemeHighContrast == false {
                     op3.state = .on
                 }
                 gestureActions.append(op3)
+
+                if #available(iOS 17.0, *) {
+                    let op4 = UIAction(title: "Light (high contrast)", image: settingsFontAwesomeImage("\u{e0c9}"), identifier: nil) { action in
+                        GlobalStruct.overrideThemeHighContrast = true
+                        GlobalStruct.overrideTheme = 1
+                        UserDefaults.standard.set(GlobalStruct.overrideThemeHighContrast, forKey: "overrideThemeHighContrast")
+                        UserDefaults.standard.set(GlobalStruct.overrideTheme, forKey: "overrideTheme")
+                        FontAwesome.setColorTheme(theme: ColorTheme.light)
+                        NotificationCenter.default.post(name: Notification.Name(rawValue: "overrideTheme"), object: nil)
+                        self.tableView.reloadRows(at: [indexPath], with: .none)
+                        
+                    }
+                    if GlobalStruct.overrideTheme == 1 && GlobalStruct.overrideThemeHighContrast == true {
+                        op4.state = .on
+                    }
+                    gestureActions.append(op4)
+                    let op5 = UIAction(title: "Dark (high contrast)", image: settingsFontAwesomeImage("\u{f186}"), identifier: nil) { action in
+                        GlobalStruct.overrideThemeHighContrast = true
+                        GlobalStruct.overrideTheme = 2
+                        UserDefaults.standard.set(GlobalStruct.overrideThemeHighContrast, forKey: "overrideThemeHighContrast")
+                        UserDefaults.standard.set(GlobalStruct.overrideTheme, forKey: "overrideTheme")
+                        FontAwesome.setColorTheme(theme: ColorTheme.dark)
+                        NotificationCenter.default.post(name: Notification.Name(rawValue: "overrideTheme"), object: nil)
+                        self.tableView.reloadRows(at: [indexPath], with: .none)
+                        
+                    }
+                    if GlobalStruct.overrideTheme == 2 && GlobalStruct.overrideThemeHighContrast == true {
+                        op5.state = .on
+                    }
+                    gestureActions.append(op5)
+                }
                 cell.backgroundButton.menu = UIMenu(title: "", image: UIImage(systemName: "sun.max"), options: [.displayInline], children: gestureActions)
                 return cell
 

--- a/Mammoth/Screens/Settings/SettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SettingsViewController.swift
@@ -169,28 +169,16 @@ class SettingsViewController: UIViewController {
     }
     
     @objc func reloadAll() {
-        DispatchQueue.main.async {
-            let hcText = UserDefaults.standard.value(forKey: "hcText") as? Bool ?? true
-            if hcText == true {
-                UIColor.custom.mainTextColor = .label
-            } else {
-                UIColor.custom.mainTextColor = .secondaryLabel
-            }
-            self.tableView.reloadData()
-            
-            // update various elements
-            self.view.backgroundColor = .custom.backgroundTint
-        }
-    }
-    
-    @objc func overrideTheme() {
-        if GlobalStruct.overrideTheme == 1 {
-            self.navigationController?.overrideUserInterfaceStyle = .light
-        } else if GlobalStruct.overrideTheme == 2 {
-            self.navigationController?.overrideUserInterfaceStyle = .dark
+        let hcText = UserDefaults.standard.value(forKey: "hcText") as? Bool ?? true
+        if hcText == true {
+            UIColor.custom.mainTextColor = .label
         } else {
-            self.navigationController?.overrideUserInterfaceStyle = .unspecified
+            UIColor.custom.mainTextColor = .secondaryLabel
         }
+        self.tableView.reloadData()
+        
+        // update various elements
+        self.view.backgroundColor = .custom.backgroundTint
     }
     
     var tempScrollPosition: CGFloat = 0
@@ -249,15 +237,6 @@ class SettingsViewController: UIViewController {
         self.view.backgroundColor = .custom.backgroundTint
         self.navigationItem.title = "Settings"
         
-        if GlobalStruct.overrideTheme == 1 {
-            self.navigationController?.overrideUserInterfaceStyle = .light
-        } else if GlobalStruct.overrideTheme == 2 {
-            self.navigationController?.overrideUserInterfaceStyle = .dark
-        } else {
-            self.navigationController?.overrideUserInterfaceStyle = .unspecified
-        }
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(self.overrideTheme), name: NSNotification.Name(rawValue: "overrideTheme"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.reloadAll), name: NSNotification.Name(rawValue: "reloadAll"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.scrollToTop), name: NSNotification.Name(rawValue: "scrollToTop9"), object: nil)
         
@@ -532,9 +511,10 @@ internal extension SettingsViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }
+         self.reloadAll()
     }
 }

--- a/Mammoth/Screens/Settings/ThemeContrastTrait.swift
+++ b/Mammoth/Screens/Settings/ThemeContrastTrait.swift
@@ -1,0 +1,33 @@
+//
+//  ThemeContrastTrait.swift
+//  Mammoth
+//
+//  Created by Riley on 1/4/24
+//  Copyright © 2024 The BLVD. All rights reserved.
+//
+
+import UIKit
+
+enum ThemeContrast: Int {
+    case standard
+    case highContrast
+}
+
+struct ThemeContrastTrait: UITraitDefinition {
+    static let defaultValue = ThemeContrast.standard
+    static let affectsColorAppearance = true
+}
+
+@available(iOS 17.0, *)
+extension UITraitCollection {
+    var themeContrast: ThemeContrast { self[ThemeContrastTrait.self] }
+}
+
+
+@available(iOS 17.0, *)
+extension UIMutableTraits {
+    var themeContrast: ThemeContrast {
+        get { self[ThemeContrastTrait.self] }
+        set { self[ThemeContrastTrait.self] = newValue }
+    }
+}

--- a/Mammoth/Screens/TabBarViewController.swift
+++ b/Mammoth/Screens/TabBarViewController.swift
@@ -700,3 +700,20 @@ extension TabBarViewController: NewPostButtonDelegate {
     }
     
 }
+
+// MARK: Appearance changes
+internal extension TabBarViewController {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.view.backgroundColor = .custom.background
+                 self.newContent1.backgroundColor = .custom.baseTint
+                 self.newContent2.backgroundColor = .custom.baseTint
+                 self.indActivity.backgroundColor = .custom.baseTint
+                 self.indActivity2.backgroundColor = .custom.baseTint
+             }
+         }
+    }
+}

--- a/Mammoth/Screens/UserListScreen/UserListViewController.swift
+++ b/Mammoth/Screens/UserListScreen/UserListViewController.swift
@@ -320,7 +320,7 @@ internal extension UserListViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }

--- a/Mammoth/Screens/WebViewController.swift
+++ b/Mammoth/Screens/WebViewController.swift
@@ -80,7 +80,7 @@ internal extension WebViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  configureNavigationBarLayout(navigationController: self.navigationController, userInterfaceStyle: self.traitCollection.userInterfaceStyle)
              }
          }

--- a/Mammoth/Screens/iPad/ColumnViewController.swift
+++ b/Mammoth/Screens/iPad/ColumnViewController.swift
@@ -460,7 +460,24 @@ class ColumnViewController: UIViewController {
     @objc func reloadAll() {
         DispatchQueue.main.async {
             self.view.backgroundColor = .custom.backgroundTint
+            let navApp = UINavigationBarAppearance()
+            navApp.configureWithOpaqueBackground()
+            navApp.backgroundColor = .custom.backgroundTint
+            navApp.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize, weight: .semibold)]
+
+            self.mainColumnNavVC?.navigationBar.standardAppearance = navApp
+            self.mainColumnNavVC?.navigationBar.scrollEdgeAppearance = navApp
+            self.mainColumnNavVC?.navigationBar.compactAppearance = navApp
+
+            self.auxColumnNavVC?.navigationBar.standardAppearance = navApp
+            self.auxColumnNavVC?.navigationBar.scrollEdgeAppearance = navApp
+            self.auxColumnNavVC?.navigationBar.compactAppearance = navApp
+
             self.mainColumnNavVC?.view.layer.borderColor = UIColor.custom.outlines.cgColor
+            self.mainColumnNavVC?.navigationBar.backgroundColor = .custom.backgroundTint
+            self.mainColumnNavVC?.view.layer.borderColor = UIColor.custom.outlines.cgColor
+            self.auxColumnNavVC?.view.layer.borderColor = UIColor.custom.outlines.cgColor
+            self.auxColumnNavVC?.navigationBar.backgroundColor = .custom.backgroundTint
             self.auxColumnNavVC?.view.layer.borderColor = UIColor.custom.outlines.cgColor
         }
     }
@@ -472,7 +489,7 @@ internal extension ColumnViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.reloadAll()
              }
          }

--- a/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
+++ b/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
@@ -14,40 +14,62 @@ extension UIColor {
     struct custom {
         
         // Previously in GlobalStruct
-        static let backgroundTint = UIColor.custom.background
-        static var baseTint = UIColor(named: "High Contrast")!
+        static var backgroundTint: UIColor { return UIColor.custom.background }
+        static var baseTint: UIColor { return appColorNamed("High Contrast") }
         static var mainTextColor = UIColor.label
         static var mainTextColor2 = UIColor.label
-        static let quoteTint = UIColor.secondarySystemBackground
-        static let actionButtons = UIColor.secondaryLabel.withAlphaComponent(0.4)
+        static var quoteTint: UIColor { return UIColor.secondarySystemBackground }
+        static var actionButtons: UIColor { return UIColor.secondaryLabel.withAlphaComponent(0.4) }
         
         // Previously used around the app
-        static let appCol = UIColor(named: "AppCol")!
-        static let selectedCell = UIColor(named: "selectedCell")!
-        static let selectedFollowing = UIColor(named: "selectedFollowing")!
-        static let spinnerBG = UIColor(named: "spinnerBG")!
+        static var appCol: UIColor { return appColorNamed("AppCol") }
+        static var selectedCell: UIColor { return appColorNamed("selectedCell") }
+        static var selectedFollowing: UIColor { return appColorNamed("selectedFollowing") }
+        static var spinnerBG: UIColor { return appColorNamed("spinnerBG") }
         
         // From Figma docs
-        static let activeInverted = UIColor(named: "Active Inverted")!
-        static let active = UIColor(named: "Active")!
-        static let background = UIColor(named: "Background")!
-        static let blurredOVRLYHigh = UIColor(named: "Blurred OVRLY High")!
-        static let blurredOVRLYMed = UIColor(named: "Blurred OVRLY Med")!
-        static let blurredOVRLYNeut = UIColor(named: "Blurred OVRLY Neut")!
-        static let destructive = UIColor(named: "Destructive")!
-        static let displayNames = UIColor(named: "Display Names")!
-        static let feintContrast = UIColor(named: "Feint Contrast")!
-        static let followButtonBG = UIColor(named: "Follow Button BG")!
-        static let highContrast = UIColor(named: "High Contrast")!
-        static let inactive = UIColor(named: "Inactive")!
-        static let linkTextInactive = UIColor(named: "Link Text Inactive")!
-        static let linkText = UIColor(named: "Link Text")!
-        static let mediumContrast = UIColor(named: "Medium Contrast")!
-        static let outlines = UIColor(named: "Outlines")!
-        static let OVRLYSoftContrast = UIColor(named: "OVRLY Soft Contrast")!
-        static let OVRLYMedContrast = UIColor(named: "OVRLY Med Contrast")!
-        static let softContrast = UIColor(named: "Soft Contrast")!
-        static let statusBar = UIColor(named: "Status Bar")!
-        static let gold = UIColor(named: "Gold")!
+        static var activeInverted: UIColor { return appColorNamed("Active Inverted") }
+        static var active: UIColor { return appColorNamed("Active") }
+        static var background: UIColor { return appColorNamed("Background") }
+        static var blurredOVRLYHigh: UIColor { return appColorNamed("Blurred OVRLY High") }
+        static var blurredOVRLYMed: UIColor { return appColorNamed("Blurred OVRLY Med") }
+        static var blurredOVRLYNeut: UIColor { return appColorNamed("Blurred OVRLY Neut") }
+        static var destructive: UIColor { return appColorNamed("Destructive") }
+        static var displayNames: UIColor { return appColorNamed("Display Names") }
+        static var feintContrast: UIColor { return appColorNamed("Feint Contrast") }
+        static var followButtonBG: UIColor { return appColorNamed("Follow Button BG") }
+        static var highContrast: UIColor { return appColorNamed("High Contrast") }
+        static var inactive: UIColor { return appColorNamed("Inactive") }
+        static var linkTextInactive: UIColor { return appColorNamed("Link Text Inactive") }
+        static var linkText: UIColor { return appColorNamed("Link Text") }
+        static var mediumContrast: UIColor { return appColorNamed("Medium Contrast") }
+        static var outlines: UIColor { return appColorNamed("Outlines") }
+        static var OVRLYSoftContrast: UIColor { return appColorNamed("OVRLY Soft Contrast") }
+        static var OVRLYMedContrast: UIColor { return appColorNamed("OVRLY Med Contrast") }
+        static var softContrast: UIColor { return appColorNamed("Soft Contrast") }
+        static var statusBar: UIColor { return appColorNamed("Status Bar") }
+        static var gold: UIColor { return appColorNamed("Gold") }
+    }
+    
+    func greenTintedColor() -> UIColor {
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return UIColor(red: red, green: green * 2.0, blue: blue, alpha: alpha)
+    }
+    static func appColorNamed(_ name: String) -> UIColor {
+#if false
+        // For testing
+        if GlobalStruct.overrideThemeHighContrast {
+            return UIColor(named: name)!.greenTintedColor()
+        } else {
+            return UIColor(named: name)!
+        }
+#else
+        let prefix = GlobalStruct.overrideThemeHighContrast ? "HC" : ""
+        return UIColor(named: prefix + name)!
+#endif
     }
 }

--- a/Mammoth/Views/AnimatedTabBar.swift
+++ b/Mammoth/Views/AnimatedTabBar.swift
@@ -232,6 +232,20 @@ class AnimatedTabBarView : UIView {
     }
 }
 
+// MARK: Appearance changes
+internal extension AnimatedTabBarView {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.selectionPill.backgroundColor = .custom.OVRLYMedContrast
+             }
+         }
+    }
+}
+
+
 class AnimatedTabBarItem: UIButton {
     private let itemTitle: String
     let unreadDot: UIView = {
@@ -320,6 +334,20 @@ class AnimatedTabBarItem: UIButton {
         return biggerFrame.contains(point)
     }
 
+}
+
+internal extension AnimatedTabBarItem {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.tintColor = .custom.mediumContrast
+                 self.setTitleColor(.custom.mediumContrast, for: .normal)
+                 self.unreadDot.backgroundColor = .custom.mediumContrast
+             }
+         }
+    }
 }
 
 fileprivate extension UIButton {

--- a/Mammoth/Views/BlurredBackground.swift
+++ b/Mammoth/Views/BlurredBackground.swift
@@ -64,7 +64,7 @@ class BlurredBackground: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  if (self.traitCollection.userInterfaceStyle == .light) {
                      underlay.backgroundColor = .custom.background.darker(by: 0.65)?.withAlphaComponent(self.isDimmed ? 0.75 : 0.35)
                  } else {

--- a/Mammoth/Views/Cells/ChannelCell.swift
+++ b/Mammoth/Views/Cells/ChannelCell.swift
@@ -241,7 +241,7 @@ internal extension ChannelCell {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
              }
          }

--- a/Mammoth/Views/Cells/ChannelSummaryCell.swift
+++ b/Mammoth/Views/Cells/ChannelSummaryCell.swift
@@ -199,7 +199,7 @@ internal extension ChannelSummaryCell {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
              }
          }

--- a/Mammoth/Views/Cells/FeedEditorCell.swift
+++ b/Mammoth/Views/Cells/FeedEditorCell.swift
@@ -232,7 +232,7 @@ internal extension FeedEditorCell {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
              }
          }

--- a/Mammoth/Views/Cells/HashtagCell.swift
+++ b/Mammoth/Views/Cells/HashtagCell.swift
@@ -205,7 +205,7 @@ internal extension HashtagCell {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
              }
          }

--- a/Mammoth/Views/Cells/InstanceCell.swift
+++ b/Mammoth/Views/Cells/InstanceCell.swift
@@ -293,7 +293,7 @@ final class InstanceCell: UITableViewCell {
             super.traitCollectionDidChange(previousTraitCollection)
             
              if #available(iOS 13.0, *) {
-                 if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+                 if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                      self.onThemeChange()
                  }
              }

--- a/Mammoth/Views/Cells/LoadMoreCell.swift
+++ b/Mammoth/Views/Cells/LoadMoreCell.swift
@@ -96,6 +96,19 @@ class LoadMoreCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+       super.traitCollectionDidChange(previousTraitCollection)
+       
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                self.contentView.backgroundColor = .custom.background
+                self.backgroundColor = .custom.background
+                titleLabel.textColor = .custom.mediumContrast
+                titleLabel.backgroundColor = .custom.background
+            }
+        }
+   }
+
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
         

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -718,36 +718,7 @@ extension PostCardCell {
             self.postTextView.backgroundColor = .custom.background
         }
         
-        
-        if self.cellVariant.hasText {
-            if self.postTextView.textContainer.maximumNumberOfLines != type.numberOfLines {
-                self.postTextView.textContainer.maximumNumberOfLines = type.numberOfLines
-            }
-            
-            if let postTextContent = postCard.metaPostText, !postTextContent.original.isEmpty {
-                self.postTextView.configure(content: postTextContent)
-                self.postTextView.isHidden = false
-                
-            } else if [.small, .hidden].contains(self.cellVariant.mediaVariant) {
-                // If there's no post text, but a media attachment,
-                // set the post text to either:
-                //  - ([type])
-                //  - ([type] description: [meta description])
-                if let type = postCard.mediaDisplayType.captializedDisplayName  {
-                    if let desc = postCard.mediaAttachments.first?.description {
-                        let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
-                        self.postTextView.configure(content: content)
-                        self.postTextView.isHidden = false
-                    } else {
-                        let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type))", emojis: [:]))
-                        self.postTextView.configure(content: content)
-                        self.postTextView.isHidden = false
-                    }
-                } else {
-                    self.postTextView.isHidden = true
-                }
-            }
-        }
+        self.configureMetaTextContent()
         
         if self.cellVariant.hasMedia {
             // Display poll if needed
@@ -919,7 +890,41 @@ extension PostCardCell {
             self.configureForDebugging(postCard: postCard)
         }
         
+        self.configureMetaTextContent()
+        
         self.configureContraints()
+    }
+    
+    func configureMetaTextContent() {
+        if self.cellVariant.hasText {
+            if self.postTextView.textContainer.maximumNumberOfLines != type!.numberOfLines {
+                self.postTextView.textContainer.maximumNumberOfLines = type!.numberOfLines
+            }
+            
+            if let postTextContent = postCard?.metaPostText, !postTextContent.original.isEmpty {
+                self.postTextView.configure(content: postTextContent)
+                self.postTextView.isHidden = false
+                
+            } else if [.small, .hidden].contains(self.cellVariant.mediaVariant) {
+                // If there's no post text, but a media attachment,
+                // set the post text to either:
+                //  - ([type])
+                //  - ([type] description: [meta description])
+                if let type = postCard?.mediaDisplayType.captializedDisplayName  {
+                    if let desc = postCard?.mediaAttachments.first?.description {
+                        let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type) description: \(desc))", emojis: [:]))
+                        self.postTextView.configure(content: content)
+                        self.postTextView.isHidden = false
+                    } else {
+                        let content = MastodonMetaContent.convert(text: MastodonContent(content: "(\(type))", emojis: [:]))
+                        self.postTextView.configure(content: content)
+                        self.postTextView.isHidden = false
+                    }
+                } else {
+                    self.postTextView.isHidden = true
+                }
+            }
+        }
     }
     
     private func configureContraints() {
@@ -1113,9 +1118,11 @@ extension PostCardCell {
         if let postCard = self.postCard, postCard.isPrivateMention {
             self.backgroundColor = .custom.OVRLYSoftContrast
             self.contentView.backgroundColor = .custom.OVRLYSoftContrast
+            self.postTextView.backgroundColor = .custom.OVRLYSoftContrast
         } else {
             self.backgroundColor = .custom.background
             self.contentView.backgroundColor = .custom.background
+            self.postTextView.backgroundColor = .custom.background
         }
 
         self.postTextView.backgroundColor = self.contentView.backgroundColor
@@ -1127,6 +1134,19 @@ extension PostCardCell {
         self.quotePost?.onThemeChange()
         self.footer.onThemeChange()
         self.footer.backgroundColor = self.contentView.backgroundColor
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Update all items that use .custom colors
+        contentWarningButton.backgroundColor = .custom.OVRLYSoftContrast
+        deletedWarningButton.backgroundColor = .custom.OVRLYSoftContrast
+        postTextView.textColor = .custom.mediumContrast
+        postTextView.backgroundColor = .custom.background
+        parentThread.backgroundColor = .custom.feintContrast
+        childThread.backgroundColor = .custom.feintContrast
+        setupUIFromSettings()
+        configureMetaTextContent()
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -890,8 +890,6 @@ extension PostCardCell {
             self.configureForDebugging(postCard: postCard)
         }
         
-        self.configureMetaTextContent()
-        
         self.configureContraints()
     }
     

--- a/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
@@ -222,6 +222,19 @@ extension PostFooterButton {
     func onThemeChange() {
         self.label.textColor = .custom.actionButtons
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Update all items that use .custom colors
+        self.backgroundColor = .custom.background
+        container.backgroundColor = .custom.background
+        label.textColor = .custom.actionButtons
+        label.backgroundColor = .custom.background
+        icon.backgroundColor = .custom.background
+        icon.image = self.postButtonType.icon(symbolConfig: symbolConfig)?.withTintColor(.custom.actionButtons,
+                             renderingMode: .alwaysOriginal)
+    }
+
 }
 
 // MARK: - Handlers

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeaderExtension.swift
@@ -106,7 +106,13 @@ extension PostCardHeaderExtension {
     
     func onThemeChange() {
         self.titleLabel.textColor = .custom.feintContrast
+        self.titleLabel.backgroundColor = .custom.background
     }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+       super.traitCollectionDidChange(previousTraitCollection)
+       onThemeChange()
+   }
 }
 
 // MARK: - Handlers

--- a/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
@@ -198,7 +198,15 @@ extension PostCardLinkPreview {
     func onThemeChange() {
         self.mainStackView.layer.borderColor = UIColor.label.withAlphaComponent(0.2).cgColor
         self.urlLabel.textColor = .custom.actionButtons
+        self.urlLabel.backgroundColor = .custom.background
+        self.titleLabel.backgroundColor = .custom.background
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+       super.traitCollectionDidChange(previousTraitCollection)
+       onThemeChange()
+   }
+
 }
 
 // MARK: - Handlers

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
@@ -176,4 +176,20 @@ final class PostCardMetadata: UIView {
             self.onButtonPress?(.replies, false, nil)
         }
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Update all items that use .custom colors
+        likesLabel.textColor = UIColor.custom.feintContrast
+        likesLabel.backgroundColor = .custom.background
+        repostsLabel.textColor = UIColor.custom.feintContrast
+        repostsLabel.backgroundColor = .custom.background
+        repliesLabel.textColor = UIColor.custom.feintContrast
+        repliesLabel.backgroundColor = .custom.background
+        applicationLabel.textColor = UIColor.custom.feintContrast
+        applicationLabel.backgroundColor = .custom.background
+        viewDetailsLabel.textColor = UIColor.custom.feintContrast
+        viewDetailsLabel.backgroundColor = .custom.background
+    }
+
 }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -202,6 +202,15 @@ extension PostCardProfilePic {
         }
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Update all items that use .custom colors
+        self.backgroundColor = .custom.background
+        profileImageView.backgroundColor = .custom.background
+        profileImageView.layer.backgroundColor = UIColor.custom.background.cgColor
+        badgeIconView.tintColor = .custom.linkText
+    }    
+    
     @objc func profileTapped() {
         if let user = user {
             self.onPress?(.profile, true, .user(user))

--- a/Mammoth/Views/Cells/PostCell.swift
+++ b/Mammoth/Views/Cells/PostCell.swift
@@ -241,7 +241,7 @@ extension PostCell {
        super.traitCollectionDidChange(previousTraitCollection)
        
         if #available(iOS 13.0, *) {
-            if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                 if (self.traitCollection.userInterfaceStyle == .light) {
                     self.contentView.backgroundColor = .custom.backgroundTint.darker(by: 2)
                 } else {

--- a/Mammoth/Views/Cells/SelectionCell.swift
+++ b/Mammoth/Views/Cells/SelectionCell.swift
@@ -15,7 +15,6 @@ class SelectionCell: UITableViewCell {
         let backgroundButton = UIButton()
         backgroundButton.translatesAutoresizingMaskIntoConstraints = true
         backgroundButton.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        backgroundButton.backgroundColor = .custom.quoteTint
         backgroundButton.showsMenuAsPrimaryAction = true
         backgroundButton.backgroundColor = .clear
         return backgroundButton
@@ -36,4 +35,18 @@ class SelectionCell: UITableViewCell {
     }
     
 }
+
+// MARK: Appearance changes
+internal extension SelectionCell {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.backgroundColor = .custom.OVRLYSoftContrast
+             }
+         }
+    }
+}
+
 

--- a/Mammoth/Views/Cells/TrendsCell.swift
+++ b/Mammoth/Views/Cells/TrendsCell.swift
@@ -204,7 +204,7 @@ extension TrendsCell {
        super.traitCollectionDidChange(previousTraitCollection)
        
         if #available(iOS 13.0, *) {
-            if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                 if (self.traitCollection.userInterfaceStyle == .light) {
                     self.contentView.backgroundColor = .custom.backgroundTint.darker(by: 2)
                 } else {

--- a/Mammoth/Views/Cells/UserCardCell/UserCardCell.swift
+++ b/Mammoth/Views/Cells/UserCardCell/UserCardCell.swift
@@ -69,7 +69,7 @@ final class UserCardCell: UITableViewCell {
 
     private var userTagLabel: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor.custom.feintContrast
+        label.textColor = .custom.feintContrast
         return label
     }()
 
@@ -263,7 +263,20 @@ extension UserCardCell {
         self.onThemeChange()
     }
     
-    func onThemeChange() {}
+    func onThemeChange() {
+        contentView.backgroundColor = .custom.background
+        titleLabel.textColor = .custom.highContrast
+        userTagLabel.textColor = .custom.feintContrast
+        descriptionLabel.textColor = .custom.mediumContrast
+        self.descriptionLabel.textAttributes = [
+            .font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular),
+            .foregroundColor: UIColor.custom.mediumContrast,
+        ]        
+        self.descriptionLabel.linkAttributes = [
+            .font: UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize + GlobalStruct.customTextSize, weight: .regular),
+            .foregroundColor: UIColor.custom.mediumContrast,
+        ]
+    }
 }
 
 // MARK: Appearance changes
@@ -272,7 +285,7 @@ internal extension UserCardCell {
         super.traitCollectionDidChange(previousTraitCollection)
         
          if #available(iOS 13.0, *) {
-             if (traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                  self.onThemeChange()
              }
          }

--- a/Mammoth/Views/NewPostButton.swift
+++ b/Mammoth/Views/NewPostButton.swift
@@ -248,3 +248,17 @@ class NewPostButton: UIButton, UIGestureRecognizerDelegate {
     }
 
 }
+
+// MARK: Appearance changes
+internal extension NewPostButton {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.backgroundColor = areColorsInverted ? .custom.active : .custom.blurredOVRLYHigh
+                 updateNewPostButtonImage()
+             }
+         }
+    }
+}

--- a/Mammoth/Views/ThinSlider.swift
+++ b/Mammoth/Views/ThinSlider.swift
@@ -27,3 +27,19 @@ class ThinSlider: UISlider {
         return CGRect(origin: point, size: CGSize(width: bounds.width, height: 1))
     }
 }
+
+// MARK: Appearance changes
+internal extension ThinSlider {
+     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+         if #available(iOS 13.0, *) {
+             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                 self.tintColor = .custom.baseTint
+                 self.minimumTrackTintColor = .custom.feintContrast
+                 self.maximumTrackTintColor = .custom.feintContrast
+             }
+         }
+    }
+}
+


### PR DESCRIPTION
- added a ThemeContrastTrait which is a UITraitDefinition
- only available on iOS 17+ where custom UITraitDefinition are available
- change the global ThemeContrastTrait when the user chooses a high-contract theme
- add high-contrast themes in Settings > Appearance
- added a set of HC (high-contrast) color assets
- added a greenTintedColor() function for testing in Xcode