### PR TITLE
Prevent the bookmark property from being incorrectly overwritten

### DIFF
--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -668,7 +668,13 @@ final class PostCardModel {
         if self.preSyncData == nil {
             self.preSyncData = self.data
         }
-        // updating the data object so that computed properties 
+        
+        // bookmarked status is local authoritative only, so remote fetched data will always be wrong
+        if (self.isBookmarked) {
+            newStatus.bookmarked = true
+        }
+
+        // updating the data object so that computed properties
         // e.g. likesCount is getting updated
         if self.isReblogged {
             if case .mastodon(let status) = data {

--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -673,6 +673,11 @@ final class PostCardModel {
         if (self.isBookmarked) {
             newStatus.bookmarked = true
         }
+        
+        // Same with if a toot has been liked outside the app, and hasLocalMetric() cannot override it
+        if (self.isLiked) {
+            newStatus.favourited = true
+        }
 
         // updating the data object so that computed properties
         // e.g. likesCount is getting updated


### PR DESCRIPTION
Currently the `PostCardModel.mergeInOriginalData()` method (used for syncing accurate like, repost and reply counts) will cause the bookmarked property to be overwritten. Since bookmark status is only accurate when you're querying your home Mastodon server, this property is always being trampled.

This PR simply makes the bookmarks property unable to be made false by a merge, if it was previously true.