### PR TITLE
MAM-3863-crash-on-build-26-394-from-bart

### DIFF
--- a/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
+++ b/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
@@ -22,7 +22,7 @@ extension UIColor {
         static var actionButtons: UIColor { return UIColor.secondaryLabel.withAlphaComponent(0.4) }
         
         // Previously used around the app
-        static var appCol: UIColor { return appColorNamed("AppCol") }
+        static var appCol: UIColor { return UIColor(named: "AppCol")! }
         static var selectedCell: UIColor { return appColorNamed("selectedCell") }
         static var selectedFollowing: UIColor { return appColorNamed("selectedFollowing") }
         static var spinnerBG: UIColor { return appColorNamed("spinnerBG") }


### PR DESCRIPTION
AppCol is global, regardless of high/regular contrast.