### PR TITLE
MAM-3870-yellow-highlights-missing-from-the-discover-tab

### DIFF
--- a/Mammoth/Views/Cells/ChannelCell.swift
+++ b/Mammoth/Views/Cells/ChannelCell.swift
@@ -221,6 +221,7 @@ extension ChannelCell {
         self.descriptionLabel.URLColor = .custom.highContrast
         self.descriptionLabel.emailColor = .custom.highContrast
         if let channel {
+            self.titleLabel.attributedText = NewsFeedTypes.channel(channel).attributedTitle()
             self.channelPic.configure(channel: channel)
         }
     }

--- a/Mammoth/Views/Cells/HashtagCell.swift
+++ b/Mammoth/Views/Cells/HashtagCell.swift
@@ -183,6 +183,9 @@ extension HashtagCell {
         self.addButton.backgroundColor = .custom.followButtonBG
         self.titleLabel.textColor = .custom.highContrast
         self.userTagLabel.textColor = UIColor.custom.feintContrast
+        if let hashtag {
+            self.titleLabel.attributedText = NewsFeedTypes.hashtag(hashtag).attributedTitle()
+        }
     }
 }
 


### PR DESCRIPTION
Reload string content on theme change since they have colored content.