### PR TITLE
MAM-3892-updateverify-some-contrast-poll-text-and-new-post-button-colors

### DIFF
--- a/Mammoth/Assets/Assets.xcassets/Colors/FAB Background.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/Colors/FAB Background.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0x56",
+          "green" : "0x56",
+          "red" : "0x56"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0xB9",
+          "green" : "0xB9",
+          "red" : "0xB9"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/Colors/FAB Foreground.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/Colors/FAB Foreground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x15",
+          "green" : "0x15",
+          "red" : "0x15"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/Colors/High Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/Colors/High Contrast.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x45",
-          "green" : "0x45",
-          "red" : "0x45"
+          "blue" : "0x38",
+          "green" : "0x38",
+          "red" : "0x38"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/Colors/Poll Bar Text.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/Colors/Poll Bar Text.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0x51",
+          "green" : "0x51",
+          "red" : "0x51"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0xC8",
+          "green" : "0xC8",
+          "red" : "0xC8"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/Colors/Poll Bars.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/Colors/Poll Bars.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0xC4",
+          "green" : "0xC4",
+          "red" : "0xC4"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x38",
+          "green" : "0x38",
+          "red" : "0x38"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCFAB Background.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCFAB Background.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0x23",
+          "green" : "0x23",
+          "red" : "0x23"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCFAB Foreground.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCFAB Foreground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0xEE",
+          "green" : "0xEE",
+          "red" : "0xEE"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Med Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Med Contrast.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xCE",
-          "green" : "0xCE",
-          "red" : "0xCE"
+          "blue" : "0xE1",
+          "green" : "0xE1",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x2F",
-          "green" : "0x2F",
-          "red" : "0x2F"
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Soft Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCOVRLY Soft Contrast.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xEB",
-          "green" : "0xEB",
-          "red" : "0xEB"
+          "blue" : "0xDE",
+          "green" : "0xDE",
+          "red" : "0xDE"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCPoll Bar Text.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCPoll Bar Text.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0x51",
+          "green" : "0x51",
+          "red" : "0x51"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0xC8",
+          "green" : "0xC8",
+          "red" : "0xC8"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCPoll Bars.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCPoll Bars.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x71",
-          "green" : "0x71",
-          "red" : "0x71"
+          "blue" : "0xC4",
+          "green" : "0xC4",
+          "red" : "0xC4"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x38",
+          "green" : "0x38",
+          "red" : "0x38"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Assets/Assets.xcassets/HCColors/HCSoft Contrast.colorset/Contents.json
+++ b/Mammoth/Assets/Assets.xcassets/HCColors/HCSoft Contrast.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3E",
-          "green" : "0x3E",
-          "red" : "0x3E"
+          "blue" : "0x35",
+          "green" : "0x35",
+          "red" : "0x35"
         }
       },
       "idiom" : "universal"

--- a/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
+++ b/Mammoth/Utils/Extensions/View/UIColor+Asset.swift
@@ -49,6 +49,10 @@ extension UIColor {
         static var softContrast: UIColor { return appColorNamed("Soft Contrast") }
         static var statusBar: UIColor { return appColorNamed("Status Bar") }
         static var gold: UIColor { return appColorNamed("Gold") }
+        static var FABBackground: UIColor { return appColorNamed("FAB Background") }
+        static var FABForeground: UIColor { return appColorNamed("FAB Foreground") }
+        static var pollBarText: UIColor { return appColorNamed("Poll Bar Text") }
+        static var pollBars: UIColor { return appColorNamed("Poll Bars") }
     }
     
     func greenTintedColor() -> UIColor {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardPoll.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardPoll.swift
@@ -220,7 +220,7 @@ fileprivate class PostCardPollOption: UIStackView {
     private var optionButton: UIButton = {
         let button = UIButton(type: .custom)
         button.backgroundColor = .clear
-        button.setTitleColor(.custom.softContrast, for: .normal)
+        button.setTitleColor( .custom.pollBarText, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .regular)
         button.titleLabel?.textAlignment = .left
         button.contentHorizontalAlignment = .left
@@ -245,7 +245,7 @@ fileprivate class PostCardPollOption: UIStackView {
     
     private var optionBar: UIView = {
         let bar = UIView()
-        bar.backgroundColor = .custom.highContrast
+        bar.backgroundColor = .custom.pollBars
         bar.translatesAutoresizingMaskIntoConstraints = false
         bar.isUserInteractionEnabled = false
         bar.layer.cornerRadius = 6

--- a/Mammoth/Views/NewPostButton.swift
+++ b/Mammoth/Views/NewPostButton.swift
@@ -32,9 +32,7 @@ class NewPostButton: UIButton, UIGestureRecognizerDelegate {
             updateNewPostButtonImage()
         }
     }
-    
-    var blurEffectView = BlurredBackground()
-    
+        
     public var allowsExtremeLeft = false
     private var leadingConstraint: NSLayoutConstraint?
     private var trailingConstraint: NSLayoutConstraint?
@@ -43,26 +41,12 @@ class NewPostButton: UIButton, UIGestureRecognizerDelegate {
     private let normalHorizontalOffset = 20.0
     private let extremeLeadingOffset = -73.0
     
-    private var areColorsInverted = DeviceHelpers.isiOSAppOnMac()
-
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = areColorsInverted ? .custom.active : .custom.blurredOVRLYHigh
+        self.backgroundColor = .custom.FABBackground
         self.clipsToBounds = true
-        
-        self.addSubview(blurEffectView)
-        self.blurEffectView.translatesAutoresizingMaskIntoConstraints = false
-        self.blurEffectView.isUserInteractionEnabled = false
-        NSLayoutConstraint.activate([
-            blurEffectView.topAnchor.constraint(equalTo: self.topAnchor),
-            blurEffectView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            blurEffectView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            blurEffectView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            ])
-        self.sendSubviewToBack(blurEffectView)
-        
-        self.bringSubviewToFront(self.imageView!)
 
+        self.bringSubviewToFront(self.imageView!)
 
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.longPressedNB))
         longPressRecognizer.minimumPressDuration = 0.5
@@ -142,7 +126,7 @@ class NewPostButton: UIButton, UIGestureRecognizerDelegate {
         } else {
             let isPrivateMessage = delegate?.newPostTypeForCurrentViewController() == .newMessage
             let imageChar = isPrivateMessage ? "@" : "\u{2b}"
-            self.setImage(FontAwesome.image(fromChar: imageChar, size: 19, weight: .bold).withTintColor(areColorsInverted ? .custom.background : .custom.active, renderingMode: .alwaysOriginal), for: .normal)
+            self.setImage(FontAwesome.image(fromChar: imageChar, size: 19, weight: .bold).withTintColor(.custom.FABForeground, renderingMode: .alwaysOriginal), for: .normal)
             self.imageEdgeInsets = .init(top: 1.5, left: 0, bottom: 0, right: 0)
             self.isHidden = false
             UIView.animate(withDuration: 0.2, animations: {
@@ -256,7 +240,7 @@ internal extension NewPostButton {
         
          if #available(iOS 13.0, *) {
              if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                 self.backgroundColor = areColorsInverted ? .custom.active : .custom.blurredOVRLYHigh
+                 self.backgroundColor = .custom.FABBackground
                  updateNewPostButtonImage()
              }
          }


### PR DESCRIPTION
- update various contrast colors
- add new colors poll text, poll bar, and 'new post' button colors
- use the new colors for poll text, and poll bars
- use new FAB colors for the New Post Button (and remove the blurEffectView