### PR TITLE
MAM-3893-toggling-high-contrast-off-discolors-activity-tab-notif

### DIFF
--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardCell.swift
@@ -18,6 +18,7 @@ final class ActivityCardCell: UITableViewCell {
     // Includes the header extension and the rest of the cell
     private var wrapperStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -29,6 +30,7 @@ final class ActivityCardCell: UITableViewCell {
     // Basic cell columns: profile pic, and cell content
     private var mainStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fillProportionally
@@ -41,6 +43,7 @@ final class ActivityCardCell: UITableViewCell {
     // Includes header, text, media
     private var contentStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .leading
         stackView.distribution = .fill
@@ -53,6 +56,7 @@ final class ActivityCardCell: UITableViewCell {
     // Includes text, small media
     private var textAndSmallMediaStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fill
@@ -100,6 +104,7 @@ final class ActivityCardCell: UITableViewCell {
     // Contains image attachment, poll, and/or link preview if needed
     private var mediaContainer: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill

--- a/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
+++ b/Mammoth/Views/Cells/ActivityCardCell/ActivityCardHeader.swift
@@ -247,7 +247,13 @@ extension ActivityCardHeader {
         }
     }
     
-    func onThemeChange() {}
+    func onThemeChange() {
+        self.backgroundColor = .custom.background
+        titleLabel.backgroundColor = .custom.background
+        dateLabel.backgroundColor = .custom.background
+        actionLabel.backgroundColor = .custom.background
+        pinIcon.backgroundColor = .custom.background
+    }
     
     func startTimeUpdates() {
         if let createdAt = self.activity?.createdAt {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -199,6 +199,7 @@ final class PostCardCell: UITableViewCell {
     // Includes the header extension and the rest of the cell
     private var wrapperStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -211,6 +212,7 @@ final class PostCardCell: UITableViewCell {
     // Basic cell columns: profile pic, and cell content
     private var mainStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fillProportionally
@@ -223,6 +225,7 @@ final class PostCardCell: UITableViewCell {
     // Includes header, text, media and footer
     private var contentStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .leading
         stackView.distribution = .fill
@@ -237,6 +240,7 @@ final class PostCardCell: UITableViewCell {
     // Includes text, small media
     private var textAndSmallMediaStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fill
@@ -306,6 +310,7 @@ final class PostCardCell: UITableViewCell {
     // Contains image attachment, poll, and/or link preview if needed
     private var mediaContainer: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -355,6 +360,8 @@ final class PostCardCell: UITableViewCell {
     
     private let parentThread: UIView = {
         let view = UIView()
+        view.isOpaque = true
+        view.layer.shouldRasterize = true
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .custom.feintContrast
         view.isHidden = true
@@ -363,6 +370,8 @@ final class PostCardCell: UITableViewCell {
     
     private let childThread: UIView = {
         let view = UIView()
+        view.isOpaque = true
+        view.layer.shouldRasterize = true
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .custom.feintContrast
         view.isHidden = true
@@ -370,6 +379,7 @@ final class PostCardCell: UITableViewCell {
     }()
     
     private var textLongPressGesture: UILongPressGestureRecognizer?
+    private var isPrivateMention: Bool = false
     
     private enum MetricButtons: Int {
         case likes
@@ -636,6 +646,7 @@ private extension PostCardCell {
         self.contentStackView.insertArrangedSubview(self.metadata!, at: self.contentStackView.arrangedSubviews.firstIndex(of: self.footer) ?? 0)
         
         setupUIFromSettings()
+        onThemeChange()
     }
     
     @objc func setupUIFromSettings() {
@@ -670,8 +681,6 @@ private extension PostCardCell {
         self.quotePost?.setupUIFromSettings()
         self.headerExtension?.setupUIFromSettings()
         self.metadata?.setupUIFromSettings()
-        
-        self.onThemeChange()
     }
 }
 
@@ -679,6 +688,9 @@ private extension PostCardCell {
 extension PostCardCell {
     func configure(postCard: PostCardModel, type: PostCardCellType = .regular, hasParent: Bool = false, hasChild: Bool = false, onButtonPress: @escaping PostCardButtonCallback) {        
         let mediaHasChanged = postCard.mediaAttachments != self.postCard?.mediaAttachments
+        
+        let shouldUpdateTheme = self.isPrivateMention != postCard.isPrivateMention
+        self.isPrivateMention = postCard.isPrivateMention
         
         self.postCard = postCard
         self.type = type
@@ -707,16 +719,6 @@ extension PostCardCell {
         
         self.header.configure(postCard: postCard, headerType: type.headerType, isVerticallyCentered: isVerticallyCentered)
         self.header.onPress = onButtonPress
-        
-        if let postCard = self.postCard, postCard.isPrivateMention {
-            self.backgroundColor = .custom.OVRLYSoftContrast
-            self.contentView.backgroundColor = .custom.OVRLYSoftContrast
-            self.postTextView.backgroundColor = .custom.OVRLYSoftContrast
-        } else {
-            self.backgroundColor = .custom.background
-            self.contentView.backgroundColor = .custom.background
-            self.postTextView.backgroundColor = .custom.background
-        }
         
         self.configureMetaTextContent()
         
@@ -843,7 +845,7 @@ extension PostCardCell {
         // Hide media gallery (carousel) if covered with content warning / deleted overlay
         if self.contentWarningButton.isHidden == false || self.deletedWarningButton.isHidden == false {
             self.mediaGallery?.alpha = 0
-        } else {
+        } else if self.mediaGallery?.alpha == 0 && postCard.mediaDisplayType == .carousel {
             self.mediaGallery?.alpha = 1
         }
         
@@ -865,7 +867,9 @@ extension PostCardCell {
             }
         } else {
             // remove the detailStack when not needed
-            self.metadata?.isHidden = true
+            if self.metadata?.isHidden == false {
+                self.metadata?.isHidden = true
+            }
         }
         
         // set detail-specific UI
@@ -882,8 +886,12 @@ extension PostCardCell {
         }
         
         // Make sure all views are underneath the contentWarningButton and the deletedWarningButton
-        self.contentStackView.bringSubviewToFront(self.contentWarningButton)
-        self.contentStackView.bringSubviewToFront(self.deletedWarningButton)
+        if self.contentWarningButton.isHidden == false {
+            self.contentStackView.bringSubviewToFront(self.contentWarningButton)
+        }
+        if self.deletedWarningButton.isHidden == false {
+            self.contentStackView.bringSubviewToFront(self.deletedWarningButton)
+        }
         
         if CommandLine.arguments.contains("-M_DEBUG_TIMELINES") {
             // Configure for debugging
@@ -891,6 +899,10 @@ extension PostCardCell {
         }
         
         self.configureContraints()
+        
+        if shouldUpdateTheme {
+            self.onThemeChange()
+        }
     }
     
     func configureMetaTextContent() {
@@ -1113,38 +1125,44 @@ extension PostCardCell {
     }
     
     func onThemeChange() {
+        var backgroundColor = UIColor.custom.background
         if let postCard = self.postCard, postCard.isPrivateMention {
-            self.backgroundColor = .custom.OVRLYSoftContrast
-            self.contentView.backgroundColor = .custom.OVRLYSoftContrast
-            self.postTextView.backgroundColor = .custom.OVRLYSoftContrast
-        } else {
-            self.backgroundColor = .custom.background
-            self.contentView.backgroundColor = .custom.background
-            self.postTextView.backgroundColor = .custom.background
+            backgroundColor = .custom.OVRLYSoftContrast
         }
-
-        self.postTextView.backgroundColor = self.contentView.backgroundColor
+        
+        self.backgroundColor = backgroundColor
+        self.contentView.backgroundColor = backgroundColor
+        self.postTextView.backgroundColor = backgroundColor
+        self.wrapperStackView.backgroundColor = backgroundColor
+        self.mainStackView.backgroundColor = backgroundColor
+        self.contentStackView.backgroundColor = backgroundColor
+        self.mediaStack?.backgroundColor = backgroundColor
+        self.mediaContainer.backgroundColor = backgroundColor
+        self.textAndSmallMediaStackView.backgroundColor = backgroundColor
         
         self.profilePic.onThemeChange()
         self.header.onThemeChange()
         self.poll?.onThemeChange()
         self.linkPreview?.onThemeChange()
         self.quotePost?.onThemeChange()
+        self.image?.onThemeChange()
+        self.metadata?.onThemeChange()
         self.footer.onThemeChange()
         self.footer.backgroundColor = self.contentView.backgroundColor
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+        
         // Update all items that use .custom colors
         contentWarningButton.backgroundColor = .custom.OVRLYSoftContrast
         deletedWarningButton.backgroundColor = .custom.OVRLYSoftContrast
         postTextView.textColor = .custom.mediumContrast
-        postTextView.backgroundColor = .custom.background
         parentThread.backgroundColor = .custom.feintContrast
         childThread.backgroundColor = .custom.feintContrast
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
         setupUIFromSettings()
         configureMetaTextContent()
+        onThemeChange()
     }
 }
 

--- a/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
@@ -75,24 +75,26 @@ private extension PostCardFooter {
 // MARK: - Configuration
 extension PostCardFooter {
     func configure(postCard: PostCardModel, includeMetrics: Bool = true) {
+        let shouldUpdateTheme = self.isPrivateMention != postCard.isPrivateMention
         self.isPrivateMention = postCard.isPrivateMention
-        if self.isPrivateMention {
-            self.backgroundColor = .custom.OVRLYSoftContrast
-        } else {
-            self.backgroundColor = .custom.background
-        }
         
         replyButton.configure(buttonText: includeMetrics ? postCard.replyCount : nil, postCard: postCard)
         repostButton.configure(buttonText: includeMetrics ? postCard.repostCount : nil, isActive: postCard.isReposted, postCard: postCard)
         likeButton.configure(buttonText: includeMetrics ? postCard.likeCount : nil, isActive: postCard.isLiked, postCard: postCard)
         moreButton.configure(buttonText: nil, isActive: postCard.isBookmarked, postCard: postCard)
+        
+        if shouldUpdateTheme {
+            self.onThemeChange()
+        }
     }
     
     func onThemeChange() {
         if self.isPrivateMention {
             self.backgroundColor = .custom.OVRLYSoftContrast
+            mainStackView.backgroundColor = .custom.OVRLYSoftContrast
         } else {
             self.backgroundColor = .custom.background
+            mainStackView.backgroundColor = .custom.background
         }
         
         replyButton.onThemeChange()

--- a/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardHeader.swift
@@ -141,6 +141,7 @@ class PostCardHeader: UIView {
     private var postCard: PostCardModel?
     private var headerType: PostCardHeaderTypes = .regular
     public var onPress: PostCardButtonCallback?
+    private var isPrivateMention: Bool = false
     
     private var subscription: Cancellable?
 
@@ -244,6 +245,9 @@ extension PostCardHeader {
             self.status = status
         }
         
+        let shouldChangeTheme = self.isPrivateMention != postCard.isPrivateMention
+        self.isPrivateMention = postCard.isPrivateMention
+        
         if headerType == .mentions {
             self.titleLabel.isHidden = false
             self.userTagLabel.isHidden = false
@@ -329,21 +333,13 @@ extension PostCardHeader {
             self.pinIcon.isHidden = true
         }
         
-        if let postCard = self.postCard, postCard.isPrivateMention {
-            self.backgroundColor = .custom.OVRLYSoftContrast
-            titleLabel.backgroundColor = .custom.OVRLYSoftContrast
-            userTagLabel.backgroundColor = .custom.OVRLYSoftContrast
-            dateLabel.backgroundColor = .custom.OVRLYSoftContrast
-        } else {
-            self.backgroundColor = .custom.background
-            titleLabel.backgroundColor = .custom.background
-            userTagLabel.backgroundColor = .custom.background
-            dateLabel.backgroundColor = .custom.background
-        }
-        
         // center header content vertically when the post has a carousel and no post text
         if isVerticallyCentered && self.userTagLabel.isHidden {
             self.directionalLayoutMargins = .init(top: 10, leading: 0, bottom: 12, trailing: 0)
+        }
+        
+        if shouldChangeTheme {
+            self.onThemeChange()
         }
     }
     
@@ -365,6 +361,21 @@ extension PostCardHeader {
     
     func onThemeChange() {
         self.profilePic?.onThemeChange()
+        var backgroundColor = UIColor.custom.background
+        
+        if let postCard = self.postCard, postCard.isPrivateMention {
+            backgroundColor = .custom.OVRLYSoftContrast
+        }
+        
+        self.backgroundColor = backgroundColor
+        titleLabel.backgroundColor = backgroundColor
+        userTagLabel.backgroundColor = backgroundColor
+        dateLabel.backgroundColor = backgroundColor
+        mainStackView.backgroundColor = backgroundColor
+        headerTitleStackView.backgroundColor = backgroundColor
+        rightAttributesStack.backgroundColor = backgroundColor
+        headerMainTitleStackView.backgroundColor = backgroundColor
+        headerTitleStackView.backgroundColor = backgroundColor
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -377,17 +388,7 @@ extension PostCardHeader {
         pinIcon.tintColor = .custom.feintContrast
         userTagLabel.textColor = .custom.feintContrast
         dateLabel.textColor = .custom.feintContrast
-        if let postCard = self.postCard, postCard.isPrivateMention {
-            self.backgroundColor = .custom.OVRLYSoftContrast
-            titleLabel.backgroundColor = .custom.OVRLYSoftContrast
-            userTagLabel.backgroundColor = .custom.OVRLYSoftContrast
-            dateLabel.backgroundColor = .custom.OVRLYSoftContrast
-        } else {
-            self.backgroundColor = .custom.background
-            titleLabel.backgroundColor = .custom.background
-            userTagLabel.backgroundColor = .custom.background
-            dateLabel.backgroundColor = .custom.background
-        }
+        
         setupUIFromSettings()
     }
     

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -237,7 +237,6 @@ final class PostCardImage: UIView {
         
         self.sensitiveContentOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.sensitiveContentOverlay.alpha = 1
-        
     }
     
     public func configure(image: Attachment?, postCard: PostCardModel) {
@@ -339,6 +338,8 @@ final class PostCardImage: UIView {
                     }
                 }
             }
+            
+            self.onThemeChange()
         }
     }
     
@@ -346,6 +347,11 @@ final class PostCardImage: UIView {
         if let firstImage = postCard.mediaAttachments.first {
             self.configure(image: firstImage, postCard: postCard)
         }
+    }
+    
+    public func onThemeChange() {
+        let backgroundColor: UIColor = (self.postCard?.isPrivateMention ?? false) ? .custom.OVRLYSoftContrast : .custom.background
+        self.backgroundColor = backgroundColor
     }
     
     private func deactivateAllImageConstraints() {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardLinkPreview.swift
@@ -18,6 +18,7 @@ class PostCardLinkPreview: UIView {
     // MARK: - Properties
     private var mainStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -34,6 +35,7 @@ class PostCardLinkPreview: UIView {
     
     private var imageStack: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -45,6 +47,7 @@ class PostCardLinkPreview: UIView {
     
     private var textStack: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -57,6 +60,7 @@ class PostCardLinkPreview: UIView {
     
     private var imageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.isOpaque = true
         imageView.contentMode = .scaleAspectFill
         imageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         imageView.backgroundColor = .custom.background
@@ -68,6 +72,7 @@ class PostCardLinkPreview: UIView {
     
     private var urlLabel: UILabel = {
         let label = UILabel()
+        label.isOpaque = true
         label.textColor = .custom.actionButtons
         label.numberOfLines = 1
         label.isOpaque = true
@@ -78,6 +83,7 @@ class PostCardLinkPreview: UIView {
     
     private var titleLabel: UILabel = {
         let label = UILabel()
+        label.isOpaque = true
         label.textColor = UIColor.label
         label.numberOfLines = 3
         label.isOpaque = true
@@ -88,6 +94,7 @@ class PostCardLinkPreview: UIView {
     
     private var status: Status?
     public var onPress: PostCardButtonCallback?
+    private var isPrivateMention = false
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -155,6 +162,7 @@ private extension PostCardLinkPreview {
         ])
         
         setupUIFromSettings()
+        onThemeChange()
     }
 }
 
@@ -165,6 +173,9 @@ extension PostCardLinkPreview {
         else { return }
         
         self.status = status
+        
+        let shouldChangeTheme = self.isPrivateMention != postCard.isPrivateMention
+        self.isPrivateMention = postCard.isPrivateMention
         
         if let urlString = postCard.formattedCardUrlStr {
             self.urlLabel.text = urlString
@@ -193,13 +204,22 @@ extension PostCardLinkPreview {
         } else {
             self.imageView.isHidden = true
         }
+        
+        if shouldChangeTheme {
+            self.onThemeChange()
+        }
     }
     
     func onThemeChange() {
         self.mainStackView.layer.borderColor = UIColor.label.withAlphaComponent(0.2).cgColor
         self.urlLabel.textColor = .custom.actionButtons
-        self.urlLabel.backgroundColor = .custom.background
-        self.titleLabel.backgroundColor = .custom.background
+        let backgroundColor: UIColor = self.isPrivateMention ? .custom.OVRLYSoftContrast : .custom.background
+        self.urlLabel.backgroundColor = backgroundColor
+        self.titleLabel.backgroundColor = backgroundColor
+        self.backgroundColor = backgroundColor
+        mainStackView.backgroundColor = backgroundColor
+        imageStack.backgroundColor = backgroundColor
+        textStack.backgroundColor = backgroundColor
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMetadata.swift
@@ -108,10 +108,12 @@ final class PostCardMetadata: UIView {
         metricsStackView.addArrangedSubview(viewDetailsLabel)
         
         self.setupUIFromSettings()
+        self.onThemeChange()
     }
     
     func configure(postCard: PostCardModel, type: PostCardCell.PostCardCellType = .regular, onButtonPress: @escaping PostCardButtonCallback) {
         self.onButtonPress = onButtonPress
+        let shouldUpdateTheme = self.isPrivateMention != postCard.isPrivateMention
         self.isPrivateMention = postCard.isPrivateMention
         
         if type.shouldShowSourceAndApplicationName {
@@ -164,7 +166,9 @@ final class PostCardMetadata: UIView {
             viewDetailsLabel.isHidden = true
         }
         
-        self.onThemeChange()
+        if shouldUpdateTheme {
+            self.onThemeChange()
+        }
     }
     
     @objc private func onMetricPress(recognizer: UIGestureRecognizer) {
@@ -181,7 +185,7 @@ final class PostCardMetadata: UIView {
         }
     }
     
-    private func onThemeChange() {
+    public func onThemeChange() {
         let backgroundColor: UIColor = isPrivateMention ? .custom.OVRLYSoftContrast : .custom.background
         likesLabel.textColor = .custom.feintContrast
         likesLabel.backgroundColor = backgroundColor
@@ -193,6 +197,9 @@ final class PostCardMetadata: UIView {
         applicationLabel.backgroundColor = backgroundColor
         viewDetailsLabel.textColor = .custom.actionButtons
         viewDetailsLabel.backgroundColor = backgroundColor
+        mainStackView.backgroundColor = backgroundColor
+        metricsStackView.backgroundColor = backgroundColor
+        self.backgroundColor = backgroundColor
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -16,6 +16,7 @@ class PostCardQuotePost: UIView {
     // MARK: - Properties
     private var mainStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -37,6 +38,7 @@ class PostCardQuotePost: UIView {
     
     private var contentStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -52,6 +54,7 @@ class PostCardQuotePost: UIView {
     // Includes text, small media
     private var textAndSmallMediaStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fill
@@ -84,6 +87,7 @@ class PostCardQuotePost: UIView {
     // Contains image attachment, poll, and/or link preview if needed
     private var mediaContainer: UIStackView = {
         let stackView = UIStackView()
+        stackView.isOpaque = true
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.distribution = .fill
@@ -507,6 +511,11 @@ extension PostCardQuotePost {
         self.linkPreview?.onThemeChange()
         self.poll?.onThemeChange()
         self.postNotFound?.onThemeChange()
+        
+        self.setupUIFromSettings()
+        
+        self.postTextLabel.backgroundColor = .custom.background
+        self.mainStackView.backgroundColor = .custom.background
     }
 }
 


### PR DESCRIPTION
- Fixed header background colors
- Set a background colors to most of the views in PostCardCell and its child views
- Move theming logic to `onThemeChange` method
- Fixing additional theming issues related to high contracts mode

[MAM-3893 : Toggling High Contrast off discolors Activity Tab notif headers](https://linear.app/theblvd/issue/MAM-3893/toggling-high-contrast-off-discolors-activity-tab-notif-headers)