### PR TITLE
MAM-3895-make-inactive-carousel-items-less-bright-in-hc-mode

### DIFF
--- a/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
+++ b/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
@@ -142,7 +142,7 @@ class Carousel: UIView {
     private func selectCell(atIndexPath indexPath: IndexPath) {
         collectionView.visibleCells.forEach({
             let cell = $0 as! CarouselItem
-            cell.titleLabel.textColor = .custom.softContrast
+            cell.titleLabel.textColor = .custom.softContrast.withAlphaComponent(GlobalStruct.overrideThemeHighContrast ? 0.65 : 1)
         })
         
         if let cell = collectionView.cellForItem(at: indexPath) as? CarouselItem {
@@ -269,7 +269,7 @@ extension Carousel: UICollectionViewDataSource {
                 cell.titleLabel.attributedText = richContent
             }
         } else {
-            cell.titleLabel.textColor = .custom.softContrast
+            cell.titleLabel.textColor = .custom.softContrast.withAlphaComponent(GlobalStruct.overrideThemeHighContrast ? 0.65 : 1)
         }
                 
         return cell

--- a/Mammoth/Screens/HomeScreen/Views/Carousel/CarouselFlowLayout.swift
+++ b/Mammoth/Screens/HomeScreen/Views/Carousel/CarouselFlowLayout.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 The BLVD. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 class CarouselFlowLayout: UICollectionViewFlowLayout {
     


### PR DESCRIPTION
[MAM-3895 : Make inactive carousel items less bright in HC-mode](https://linear.app/theblvd/issue/MAM-3895/make-inactive-carousel-items-less-bright-in-hc-mode)

Making the active carousel item pop by putting the inactive items on 65% opacity. Only in high-contrast mode.

<img width="490" alt="Screenshot 2024-02-06 at 15 53 25" src="https://github.com/TheBLVD/mammoth/assets/221925/5562f6e6-3a8f-4156-8746-90647cf6ec67">
<img width="497" alt="Screenshot 2024-02-06 at 15 53 14" src="https://github.com/TheBLVD/mammoth/assets/221925/3ba23782-b5bb-45fd-84f2-960f3e754059">
