### PR TITLE
MAM-3896-performance-do-not-update-the-feed-when-scrolling-and

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -712,14 +712,14 @@ extension NewsFeedViewController {
     
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         self.cacheScrollPosition(tableView: self.tableView, forFeed: self.viewModel.type)
-        
-        let tasks = self.deferredSnapshotUpdates
-        self.deferredSnapshotUpdates = []
-        tasks.forEach({ $0() })
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         self.cacheScrollPosition(tableView: self.tableView, forFeed: self.viewModel.type)
+        
+        let tasks = self.deferredSnapshotUpdates
+        self.deferredSnapshotUpdates = []
+        tasks.forEach({ $0() })
     }
 }
 
@@ -735,7 +735,7 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
         
         let updateDisplay = (NewsFeedTypes.allActivityTypes + [.mentionsIn, .mentionsOut]).contains(feedType) || self.isInWindowHierarchy()
         
-        guard !self.tableView.isTracking, updateDisplay else {
+        guard !self.tableView.isTracking, !self.tableView.isDecelerating, updateDisplay else {
             let deferredJob = {  [weak self] in
                 guard let self else { return }
                 self.didUpdateSnapshot(snapshot, feedType: feedType, updateType: updateType, onCompleted: onCompleted)


### PR DESCRIPTION
When new content is being injected in the feed when scrolling, an animation hitch could occur. To prevent this we might want to only update the feed when it's not moving. 

IMPORTANT to do an in-depth QA of the feed experience before we ship this.

[MAM-3896 : Performance: do not update the feed when scrolling and decelerating](https://linear.app/theblvd/issue/MAM-3896/performance-do-not-update-the-feed-when-scrolling-and-decelerating)