### PR TITLE
Add clearCache() to StatusCache and hook up to clearAllCaches()

### DIFF
--- a/Mammoth/Managers/StatusCache.swift
+++ b/Mammoth/Managers/StatusCache.swift
@@ -66,6 +66,26 @@ class StatusCache {
         }
     }
     
+    public func clearCache() {
+        StatusCache.cachedStatusesLock.lock()
+        StatusCache.cachedStatuses.removeAll()
+        StatusCache.cachedStatusesLock.unlock()
+        
+        StatusCache.nilValuesURLsLock.lock()
+        StatusCache.nilValueURLs.removeAll()
+        StatusCache.nilValuesURLsLock.unlock()
+        
+        self.localLikes = [:]
+        self.localReposts = [:]
+        self.localBookmarks = [:]
+        
+        if let userId = AccountsManager.shared.currentUser()?.fullAcct {
+            GlobalStruct.allLikes = []
+            GlobalStruct.allReposts = []
+            GlobalStruct.allBookmarks = []
+        }
+    }
+    
     public func cachedStatusForURL(url: URL) -> Status? {
         // Return immedidately if we've cached this
         StatusCache.cachedStatusesLock.lock()

--- a/Mammoth/Managers/StatusCache.swift
+++ b/Mammoth/Managers/StatusCache.swift
@@ -79,11 +79,9 @@ class StatusCache {
         self.localReposts = [:]
         self.localBookmarks = [:]
         
-        if let userId = AccountsManager.shared.currentUser()?.fullAcct {
-            GlobalStruct.allLikes = []
-            GlobalStruct.allReposts = []
-            GlobalStruct.allBookmarks = []
-        }
+        GlobalStruct.allLikes = []
+        GlobalStruct.allReposts = []
+        GlobalStruct.allBookmarks = []
     }
     
     public func cachedStatusForURL(url: URL) -> Status? {

--- a/Mammoth/Screens/Settings/SettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SettingsViewController.swift
@@ -523,6 +523,7 @@ extension SettingsViewController {
         FeedsManager.shared.clearCache()
         ModerationManager.shared.clearCache()
         TutorialOverlay.resetTutorials()
+        StatusCache.shared.clearCache()
 
         // Clear News Carousel Cache
         do {


### PR DESCRIPTION
During my bookmark testing I noticed we did not purge any of the state accumulated in `StatusCache`, so this adds a basic method and hooks it up to `SettingsViewController.clearAllCaches()`.