### PR TITLE
MAM-3882-filter-out-known-followed-accounts-client-side

### DIFF
--- a/Mammoth/Screens/DiscoveryScreen/DiscoverSuggestionsViewModel.swift
+++ b/Mammoth/Screens/DiscoveryScreen/DiscoverSuggestionsViewModel.swift
@@ -254,7 +254,13 @@ extension DiscoverSuggestionsViewModel {
                     guard let self else { return }
                     do {
                         let accounts = try await AccountService.getFollowRecommentations(fullAcct: fullAcct)
-                        let userCards = accounts.map({ account in
+                        // Filter out accounts that the user is already following,
+                        // and randomize the results
+                        let unfollowedAccounts = accounts.filter { account in
+                            return FollowManager.shared.followStatusForAccount(account, requestUpdate: .none) != .following
+                        }.shuffled()
+                        
+                        let userCards = unfollowedAccounts.map({ account in
                             UserCardModel.fromAccount(account: account, instanceName: GlobalHostServer())
                         })
                         


### PR DESCRIPTION
I ended up doing both of these, as they were so related:
https://linear.app/theblvd/issue/MAM-3882/filter-out-known-followed-accounts-client-side
https://linear.app/theblvd/issue/MAM-3883/randomize-suggested-follows-client-side

- filter out accounts that are known to be followed
- randomize the results