### PR TITLE
MAM-3926-nav-cleanup-carousel-item-context-menu-without-blur

### DIFF
--- a/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
+++ b/Mammoth/Screens/HomeScreen/Views/Carousel/Carousel.swift
@@ -277,22 +277,10 @@ extension Carousel: UICollectionViewDataSource {
         } else {
             cell.titleLabel.textColor = .custom.softContrast.withAlphaComponent(GlobalStruct.overrideThemeHighContrast ? 0.65 : 1)
         }
+        
+        let menu = self.delegate?.contextMenuForItem(withIndex: indexPath.item)
+        cell.menuButton.menu = menu
                 
         return cell
-    }
-}
-
-// MARK: UIContextMenuInteractionDelegate
-extension Carousel: UIContextMenuInteractionDelegate {
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        return nil
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let cell = collectionView.cellForItem(at: indexPath), cell.isSelected else { return nil }
-        guard let menu = self.delegate?.contextMenuForItem(withIndex: indexPath.item) else { return nil }
-        return UIContextMenuConfiguration(identifier: indexPath as NSIndexPath, previewProvider: nil, actionProvider: { suggestedActions in
-            return menu
-        })
     }
 }

--- a/Mammoth/Screens/HomeScreen/Views/Carousel/CarouselItem.swift
+++ b/Mammoth/Screens/HomeScreen/Views/Carousel/CarouselItem.swift
@@ -12,6 +12,19 @@ class CarouselItem: UICollectionViewCell {
     static let reuseIdentifier = "CarouselItem"
 
     let titleLabel = UILabel()
+    let menuButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.showsMenuAsPrimaryAction = false
+        button.isEnabled = false
+        return button
+    }()
+    
+    override var isSelected: Bool {
+        didSet {
+            self.menuButton.isEnabled = isSelected
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,6 +42,10 @@ class CarouselItem: UICollectionViewCell {
         titleLabel.textColor = .custom.highContrast
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(titleLabel)
+        
+        contentView.addSubview(menuButton)
+        
+        menuButton.pinEdges()
 
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),


### PR DESCRIPTION
[MAM-3926 : Nav cleanup: carousel item context menu without blur](https://linear.app/theblvd/issue/MAM-3926/nav-cleanup-carousel-item-context-menu-without-blur)

https://github.com/TheBLVD/mammoth/assets/221925/6b4355bf-c9f1-4286-9a70-f36ca5b23fb9


