### PR TITLE
MAM-3928-use-new-follow-suggestions-endpoint

### DIFF
--- a/Mammoth/Managers/AccountsManager/AccountsManager.swift
+++ b/Mammoth/Managers/AccountsManager/AccountsManager.swift
@@ -463,6 +463,16 @@ extension AccountsManager {
         }
     }
 
+    var currentAccountFeatureClient: Client {
+        if let currentAccount = self.currentAccount as? MastodonAcctData {
+            return currentAccount.featureClient
+        } else {
+            log.error("currentAccountFeatureClient called with no active account")
+            // Not really a valid client
+            return Client(baseURL: "https://feature.moth.social")
+        }
+    }
+
     var currentAccountBlueskyAPI: BlueskyAPI? {
         let account = currentAccount as? BlueskyAcctData
         return account?.api

--- a/Mammoth/Managers/AccountsManager/AcctData.swift
+++ b/Mammoth/Managers/AccountsManager/AcctData.swift
@@ -116,7 +116,8 @@ struct MastodonAcctData: AcctDataType {
     
     let client: Client
     let mothClient: Client
-    
+    let featureClient: Client
+
     private enum CodingKeys: String, CodingKey {
         case uniqueID
         case account
@@ -134,6 +135,7 @@ struct MastodonAcctData: AcctDataType {
         self.instanceData = instanceData
         self.client = Client(baseURL: "https://\(instanceData.returnedText)", accessToken: instanceData.accessToken)
         self.mothClient = Client(baseURL: "https://\(GlobalHostServer())", accessToken: MothSocialJWT(acct: account.remoteFullOriginalAcct), isMothClient: true)
+        self.featureClient = Client(baseURL: "https://feature.moth.social", accessToken: MothSocialJWT(acct: account.remoteFullOriginalAcct), isMothClient: true)
         self.defaultPostVisibility = defaultPostVisibility
         self.defaultPostingLanguage = defaultPostingLanguage
         self.emoticons = emoticons
@@ -148,6 +150,7 @@ struct MastodonAcctData: AcctDataType {
         instanceData = try container.decode(InstanceData.self, forKey: .instanceData)
         client = Client(baseURL: "https://\(instanceData.returnedText)", accessToken: instanceData.accessToken)
         mothClient = Client(baseURL: "https://\(GlobalHostServer())", accessToken: MothSocialJWT(acct: account.remoteFullOriginalAcct), isMothClient: true)
+        featureClient = Client(baseURL: "https://feature.moth.social", accessToken: MothSocialJWT(acct: account.remoteFullOriginalAcct), isMothClient: true)
         // Below are new for 2.0
         do {
             defaultPostVisibility = try container.decode(Visibility.self, forKey: .defaultPostVisibility)

--- a/Mammoth/Screens/DiscoveryScreen/DiscoveryViewModel.swift
+++ b/Mammoth/Screens/DiscoveryScreen/DiscoveryViewModel.swift
@@ -176,30 +176,6 @@ extension DiscoveryViewModel {
 extension DiscoveryViewModel {
     func loadRecommendations() async {
         self.state = .loading
-        if let fullAcct = AccountsManager.shared.currentUser()?.fullAcct {
-            do {
-                let accounts = try await AccountService.getFollowRecommentations(fullAcct: fullAcct)
-
-                let userCards = accounts.map({ account in
-                    UserCardModel.fromAccount(account: account, instanceName: GlobalHostServer())
-                })
-                
-                UserCardModel.preload(userCards: userCards)
-                
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    self.suggested = userCards
-                    self.listData = userCards
-                    self.state = .success
-                }
-                
-            } catch let error {
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    self.state = .error(error)
-                }
-            }
-        }
     }
     
     func search(query: String, fullSearch: Bool = false) {

--- a/Mammoth/Services/Backend/AccountService.swift
+++ b/Mammoth/Services/Backend/AccountService.swift
@@ -89,8 +89,8 @@ struct AccountService {
     // fallback to suggested recommendations from current instance
     static func getFollowRecommentations(fullAcct: String) async throws -> [Account] {
         do {
-            let request = Accounts.followRecommendationsV2(fullAcct)
-            let result = try await ClientService.runMothRequest(request: request)
+            let request = Accounts.followRecommendationsV3(fullAcct)
+            let result = try await ClientService.runFeatureRequest(request: request)
             return result
         } catch let error {
             log.debug("FollowRecommentations failed to Moth.social: \(error)")

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Accounts.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Accounts.swift
@@ -365,12 +365,12 @@ public struct Accounts {
     ///
     /// - Parameter fullAcct: The fully qualified account name (e.g. "mammoth@moth.social")
     /// - Returns: Accounts from the users followers using fedi-graph
-    public static func followRecommendationsV2(_ fullAcct: String) -> Request<[Account]> {
+    public static func followRecommendationsV3(_ fullAcct: String) -> Request<[Account]> {
         let parameters = [
             Parameter(name: "acct", value: fullAcct),
         ]
         let method = HTTPMethod.get(.parameters(parameters))
-        return Request<[Account]>(path: "/api/v2/follow_recommendations", method: method)
+        return Request<[Account]>(path: "/api/v1/followgraph", method: method)
     }
 
     public static func onboardingFollowRecommendations() -> Request<[Category]> {


### PR DESCRIPTION
- stop requesting follow suggestions in DiscoverViewModel (the model used for showing Account search results; it doesn't need the suggestions)
- create a featureClient, similar to client, mothClient
- use the featureClient to get follow suggestions