### PR TITLE
MAM-3934-invalid-quote-causing-crash

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardQuotePost.swift
@@ -334,6 +334,7 @@ private extension PostCardQuotePost {
         self.postNotFound!.isHidden = true
         self.postNotFound!.isUserInteractionEnabled = false
         self.postNotFound!.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.addArrangedSubview(self.postNotFound!)
         postNotFoundTrailingConstraint = self.postNotFound!.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: -self.contentStackView.directionalLayoutMargins.trailing)
         
         NSLayoutConstraint.activate([


### PR DESCRIPTION
An exception was being thrown when attempting to display "Post could not be found" as the postNotFound view was not in the view hierarchy.