### PR TITLE
MAM-3950-avatar-top-left-on-profile-buggy

### DIFF
--- a/Mammoth/Views/AccountSwitcherButton.swift
+++ b/Mammoth/Views/AccountSwitcherButton.swift
@@ -54,7 +54,7 @@ class AccountSwitcherButton: UIButton {
     
     private func onThemeChange() {
         self.layer.borderColor = (UIDevice.current.userInterfaceIdiom == .phone)
-        ? UIColor.custom.OVRLYMedContrast.withAlphaComponent(0.7).cgColor
+        ? UIColor.clear.cgColor
         : UIColor.custom.outlines.cgColor
     }
     
@@ -89,7 +89,7 @@ class AccountSwitcherButton: UIButton {
                     with: avatarURL,
                     for: .normal,
                     placeholderImage: nil,
-                    context: [.imageTransformer: PostCardProfilePic.transformer],
+                    context: [.imageTransformer: PostCardProfilePic.transformerAlwaysCircle],
                     progress: nil
                 )
             } else {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -58,6 +58,18 @@ final class PostCardProfilePic: UIButton {
         return SDImagePipelineTransformer(transformers: [resizeTransformer, roundTransformer])
     }
     
+    static var transformerAlwaysCircle: SDImagePipelineTransformer {
+        let scale = UIScreen.main.scale
+        let thumbnailSize = CGSize(width: PostCardProfilePic.ProfilePicSize.regular.width() * scale, height: PostCardProfilePic.ProfilePicSize.regular.width() * scale)
+        let resizeTransformer = SDImageResizingTransformer(size: thumbnailSize, scaleMode: .aspectFit)
+        let roundTransformer = SDImageRoundCornerTransformer(
+            radius: .greatestFiniteMagnitude,
+            corners: .allCorners,
+            borderWidth: 0,
+            borderColor: nil)
+        return SDImagePipelineTransformer(transformers: [resizeTransformer, roundTransformer])
+    }
+    
     // MARK: - Properties
     
     private(set) var profileImageView: UIImageView = {
@@ -200,6 +212,15 @@ extension PostCardProfilePic {
     }
     
     func onThemeChange() {
+        // This is also called when the avatar changes from round/square
+        self.profileImageView.layer.cornerRadius = self.size.cornerRadius()
+        if let profileStr = self.user?.imageURL, let profileURL = URL(string: profileStr) {
+            self.profileImageView.ma_setImage(with: profileURL,
+                                              cachedImage: nil,
+                                              imageTransformer: PostCardProfilePic.transformer) { image in
+            }
+        }
+        
         let backgroundColor: UIColor = isPrivateMention ? .custom.OVRLYSoftContrast : .custom.background
         self.profileImageView.backgroundColor = backgroundColor
         profileImageView.layer.backgroundColor = backgroundColor.cgColor

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -204,7 +204,7 @@ extension PostCardProfilePic {
             self.badge.isHidden = true
         }
         
-        self.onThemeChange()
+        updateColors()
     }
     
     func optimisticUpdate(image: UIImage) {
@@ -221,6 +221,10 @@ extension PostCardProfilePic {
             }
         }
         
+        updateColors()
+    }
+     
+    func updateColors() {
         let backgroundColor: UIColor = isPrivateMention ? .custom.OVRLYSoftContrast : .custom.background
         self.profileImageView.backgroundColor = backgroundColor
         profileImageView.layer.backgroundColor = backgroundColor.cgColor


### PR DESCRIPTION
- use the correct border color in the account switcher button when the theme updates
- always use a circle transform for the account button
- re-set the main profile avatar image when changing between square/circle