### PR TITLE
MAM-3946-macos-account-switcher-bug-in-27

### DIFF
--- a/Mammoth/Views/AccountSwitcherButton.swift
+++ b/Mammoth/Views/AccountSwitcherButton.swift
@@ -146,7 +146,13 @@ class AccountSwitcherButton: UIButton {
             AccountsManager.shared.allAccounts.count > 1 ? accountSettings : nil
         ].compactMap({$0}))
         
-        return UIMenu(title: "", options: [.displayInline], children: [accountsMenu, settingsMenu])
+        if DeviceHelpers.isiOSAppOnMac() {
+            var menuItems: [UIMenuElement] = accountsMenu.children
+            menuItems.append(settingsMenu)
+            return UIMenu(title: "", children: menuItems)
+        } else {
+            return UIMenu(title: "", options: [.displayInline], children: [accountsMenu, settingsMenu])
+        }
     }
     
     


### PR DESCRIPTION
Use the proper menu structure for macOS as needed.