### PR TITLE
MAM-3951-macos-no-suggested-follows

### DIFF
--- a/Mammoth/Screens/DiscoveryScreen/DiscoveryViewModel.swift
+++ b/Mammoth/Screens/DiscoveryScreen/DiscoveryViewModel.swift
@@ -176,6 +176,35 @@ extension DiscoveryViewModel {
 extension DiscoveryViewModel {
     func loadRecommendations() async {
         self.state = .loading
+        
+        // No need to load default content on the iPhone
+        guard self.position == .aux else { return }
+        
+        if let fullAcct = AccountsManager.shared.currentUser()?.fullAcct {
+            do {
+                let accounts = try await AccountService.getFollowRecommentations(fullAcct: fullAcct)
+
+                let userCards = accounts.map({ account in
+                    UserCardModel.fromAccount(account: account, instanceName: GlobalHostServer())
+                })
+                
+                UserCardModel.preload(userCards: userCards)
+                
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.suggested = userCards
+                    self.listData = userCards
+                    self.state = .success
+                }
+                
+            } catch let error {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.state = .error(error)
+                }
+            }
+        }
+
     }
     
     func search(query: String, fullSearch: Bool = false) {


### PR DESCRIPTION
Reinstate the initial request for account content. It's not needed for iPhone, but is for iPad/macOS.