### PR TITLE
MAM-3963-animated-gifs-display-incorrectly-in-account-switcher-button

### DIFF
--- a/Mammoth/Views/AccountSwitcherButton.swift
+++ b/Mammoth/Views/AccountSwitcherButton.swift
@@ -50,6 +50,7 @@ class AccountSwitcherButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         self.layer.cornerRadius = self.frame.height / 2.0
+        self.imageView?.layer.cornerRadius = self.frame.height / 2.0 - self.layer.borderWidth
     }
     
     private func onThemeChange() {
@@ -89,7 +90,6 @@ class AccountSwitcherButton: UIButton {
                     with: avatarURL,
                     for: .normal,
                     placeholderImage: nil,
-                    context: [.imageTransformer: PostCardProfilePic.transformerAlwaysCircle],
                     progress: nil
                 )
             } else {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardProfilePic.swift
@@ -57,19 +57,7 @@ final class PostCardProfilePic: UIButton {
             borderColor: nil)
         return SDImagePipelineTransformer(transformers: [resizeTransformer, roundTransformer])
     }
-    
-    static var transformerAlwaysCircle: SDImagePipelineTransformer {
-        let scale = UIScreen.main.scale
-        let thumbnailSize = CGSize(width: PostCardProfilePic.ProfilePicSize.regular.width() * scale, height: PostCardProfilePic.ProfilePicSize.regular.width() * scale)
-        let resizeTransformer = SDImageResizingTransformer(size: thumbnailSize, scaleMode: .aspectFit)
-        let roundTransformer = SDImageRoundCornerTransformer(
-            radius: .greatestFiniteMagnitude,
-            corners: .allCorners,
-            borderWidth: 0,
-            borderColor: nil)
-        return SDImagePipelineTransformer(transformers: [resizeTransformer, roundTransformer])
-    }
-    
+        
     // MARK: - Properties
     
     private(set) var profileImageView: UIImageView = {


### PR DESCRIPTION
Set the UIButton.imageView layer cornerRadius instead of using SDImagePipelineTransformer which doesn't seem to work for GIFs on UIButtons.
(It does seem to work on UIImageViews as in PostCardProfilePic)