### PR TITLE
MAM-3972-remove-for-you-beta-features

### DIFF
--- a/Mammoth/Screens/ForYouCustomizationScreen/ForYouCustomizationViewModel.swift
+++ b/Mammoth/Screens/ForYouCustomizationScreen/ForYouCustomizationViewModel.swift
@@ -123,7 +123,7 @@ extension ForYouCustomizationViewModel {
         //      - Mammoth Picks
         //      - Smart Lists
         //      - Beta
-        return 3
+        return 2 // Was 3; we no longer show the beta features
     }
     
     func hasHeader(forSection sectionIndex: Int) -> Bool {


### PR DESCRIPTION
Hide the 'beta' / third section in the For You customization view.