### PR TITLE
MAM-3869 Fix bookmark and favourite list scrolling

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+DataSource.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+DataSource.swift
@@ -454,7 +454,9 @@ extension NewsFeedViewModel {
                 self.snapshot.deleteSections([.main])
                 self.snapshot = self.appendMainSectionToSnapshot(snapshot: self.snapshot)
                 
-                guard retrievedItems != nil else {
+                // Until we refactor persistence to store nextPageRange / previousPageRange
+                // we cannot accurately restore the state of any feedType that makes paginated requests
+                guard retrievedItems != nil && !makePaginatedRequest else {
                     self.state = .success
                     completed?()
                     return

--- a/Mammoth/Services/Backend/MastodonKit/RequestRange.swift
+++ b/Mammoth/Services/Backend/MastodonKit/RequestRange.swift
@@ -53,6 +53,27 @@ extension RequestRange {
     }
 }
 
+extension RequestRange: Comparable {
+    private static func requestRangeIdToIntegers(_ range: RequestRange) -> Int {
+        switch range {
+        case let .max(id, _):
+            return Int(id) ?? 0
+        case let .min(id, _):
+            return Int(id) ?? 0
+        default:
+            print("Warning: unsupported comparison for RequestRange")
+            return 0
+        }
+    }
+    
+    public static func < (lhs: RequestRange, rhs: RequestRange) -> Bool {
+        // guard that both lhs and rhs have the same type
+        let lhsVal = requestRangeIdToIntegers(lhs)
+        let rhsVal = requestRangeIdToIntegers(rhs)
+        
+        return lhsVal < rhsVal
+    }
+}
 // MARK: - Equatable
 
 extension RequestRange: Equatable {}

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Bookmarks.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Bookmarks.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct Bookmarks {
-    public static func bookmarks(range: RequestRange = .default) -> Request<[Status]> {
+    public static func all(range: RequestRange = .default) -> Request<[Status]> {
         let rangeParameters = range.parameters(limit: between(1, and: 40, default: 20)) ?? []
         let method = HTTPMethod.get(.parameters(rangeParameters))
         

--- a/Mammoth/Services/Backend/TimelineService.swift
+++ b/Mammoth/Services/Backend/TimelineService.swift
@@ -97,16 +97,17 @@ struct TimelineService {
         return result
     }
     
-    static func likes(range: RequestRange = .default) async throws -> ([Status], cursorId: String?) {
+    static func likes(range: RequestRange = .default) async throws -> ([Status], Pagination?, cursorId: String?) {
         let request = Favourites.all(range: range)
-        let result = try await ClientService.runRequest(request: request)
-        return (result, cursorId: result.last?.id)
+        let (result, pagination) = try await ClientService.runPaginatedRequest(request: request)
+        return (result, pagination, cursorId: result.last?.id)
     }
 
-    static func bookmarks(range: RequestRange = .default) async throws -> ([Status], cursorId: String?) {
-        let request = Bookmarks.bookmarks(range: range)
-        let result = try await ClientService.runRequest(request: request)
-        return (result, cursorId: result.last?.id)
+    static func bookmarks(range: RequestRange = .default) async throws -> ([Status], Pagination?, cursorId: String?) {
+        let request = Bookmarks.all(range: range)
+
+        let (result, pagination) = try await ClientService.runPaginatedRequest(request: request)
+        return (result, pagination, cursorId: result.last?.id)
     }
     
     static func mentions(range: RequestRange = .default) async throws -> ([Status], cursorId: String?) {


### PR DESCRIPTION
- Added `NewsFeedViewModel.makePaginatedRequest` to determine which feed types make paginated requests.
- Changed bookmarks and favourites to use `fetchAllPaginated()`
- Added `nextPageRange` and `previousPageRange` to NewsFeedViewModel to store our position in the paginated data
- Making paginated requests for unsupported feedTypes will throw the new `NewsFeedViewModelError.invalidFeedType`
- Removed cache hydration for all paginated feed types, as we cannot locate you correctly within the pages without storing the previous/next responses from the server. This intervention is made in `NewsFeedViewModel.syncDataSource()`. We still persist and retrieve the data, it is just ignored for now.
- Added a missing call to `shouldPollForListData` before `startPollingListData()`
- Added bookmarks to the exclude list of `shouldPollForListData` and `shouldSyncItems`
- One or two other minor fixes