### PR TITLE
Fix issue with the '@' prefix not being added appropriately in Mention function

### DIFF
--- a/Mammoth/Services/Backend/MastodonKit/Models/Account.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Account.swift
@@ -147,7 +147,7 @@ public class AccountSource: Codable {
 public extension Account {
     
     /// The account server, regardless of whether it's on the user's same server.
-    /// Example: "@mammoth@moth.social" would return "moth.social"
+    /// Example: "mammoth@moth.social" would return "moth.social"
     var server: String {
         var server = ""
         if let otherUserURL = URL(string: self.url) {
@@ -166,7 +166,7 @@ public extension Account {
     
     
     /// The fully formed acct regardless whether it's on the user's same server.
-    /// Example: "@mammoth" would return "@mammoth@moth.social"
+    /// Example: "mammoth" would return "mammoth@moth.social"
     var fullAcct: String {
         // lowercase to increase chances of == succeeding
         // when comparing accounts from various sources
@@ -174,8 +174,8 @@ public extension Account {
     }
     
     /// The fully formed acct with original letter casing.
-    ///  "@rileyhBat@moth.social" will return it as it is on the servers
-    /// Example: "@Mammoth" would return "@Mammoth@moth.social"
+    ///  "rileyhBat@moth.social" will return it as it is on the servers
+    /// Example: username "Mammoth" would return "Mammoth@moth.social"
     var remoteFullOriginalAcct: String {
         // If the username and acct are the same, then this
         // account is on the same server as the user.

--- a/Mammoth/Utils/UserActions.swift
+++ b/Mammoth/Utils/UserActions.swift
@@ -132,7 +132,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "\(user.remoteFullOriginalAcct) "
+        vc.proText = "@\(user.remoteFullOriginalAcct) "
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }
     
@@ -140,7 +140,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "\(user.remoteFullOriginalAcct) "
+        vc.proText = "@\(user.remoteFullOriginalAcct) "
         vc.whoCanReply = .direct
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }

--- a/Mammoth/Utils/UserActions.swift
+++ b/Mammoth/Utils/UserActions.swift
@@ -132,7 +132,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "@\(user.remoteFullOriginalAcct) LETS GOOOO"
+        vc.proText = "@\(user.remoteFullOriginalAcct) "
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }
     

--- a/Mammoth/Utils/UserActions.swift
+++ b/Mammoth/Utils/UserActions.swift
@@ -140,7 +140,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "\(user.remoteFullOriginalAcct) "
+        vc.proText = "@\(user.remoteFullOriginalAcct) "
         vc.whoCanReply = .direct
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }

--- a/Mammoth/Utils/UserActions.swift
+++ b/Mammoth/Utils/UserActions.swift
@@ -132,7 +132,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "@\(user.remoteFullOriginalAcct) "
+        vc.proText = "@\(user.remoteFullOriginalAcct) LETS GOOOO"
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }
     
@@ -140,7 +140,7 @@ struct UserActions {
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
         vc.fromPro = true
-        vc.proText = "@\(user.remoteFullOriginalAcct) "
+        vc.proText = "\(user.remoteFullOriginalAcct) "
         vc.whoCanReply = .direct
         target.present(UINavigationController(rootViewController: vc), animated: true)
     }


### PR DESCRIPTION
On a user profile page, if you select "Mention" from the top right menu, it incorrectly misses out the '@' prefix for the full username. I've added it, plus changed the comments in UserActions to be clearer about what is happening.
