### PR TITLE
MAM-3998-bump-metatextkit-version-to-latest

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -4819,7 +4819,7 @@
 			repositoryURL = "https://github.com/TheBLVD/MetaTextKit";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.10;
+				version = 2.3.11;
 			};
 		};
 		532F291329476916003C9FAD /* XCRemoteSwiftPackageReference "MessageKit" */ = {


### PR DESCRIPTION
https://linear.app/theblvd/issue/MAM-3998/bump-metatextkit-version-to-latest