### PR TITLE
MAM-3626-consider-use-url-search-on-instance-to-get-quote-post-from

### DIFF
--- a/Mammoth/Managers/StatusCache.swift
+++ b/Mammoth/Managers/StatusCache.swift
@@ -125,59 +125,23 @@ class StatusCache {
             return
         } else {
             // Make the network request, then the callback
-            guard let server = url.host else {
-                completion(url, nil)
-                return
-            }
-            
-            // Special case for threads.net posts
-            if server.hasSuffix("www.threads.net") {
-                Task {
-                    let baseURL = "https://feature.moth.social"
-                    let request = URLRequest(url: URL(string: "\(baseURL)/api/v1/status/lookup?url=\(url.absoluteString)")!)
-                    do {
-                        let (data, response) = try await URLSession.shared.data(for: request)
-                        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
-                            let stat = try JSONDecoder().decode(Status.self, from: data)
-                            await MainActor.run {
-                                StatusCache.cachedStatusesLock.lock()
-                                StatusCache.cachedStatuses[url] = stat
-                                StatusCache.cachedStatusesLock.unlock()
-                            }
-                            
-                            completion(url, stat)
-                        }
-                    } catch {
-                        log.error("can't load thread post")
-                        completion(url, nil)
-                    }
-                }
-                
-            } else {
-                let originalPostID = url.lastPathComponent
-                let client = Client(baseURL: "https://\(server)")
-                let request = Statuses.status(id: originalPostID)
-                client.run(request) { (statuses) in
-                    var stat: Status? = nil
-                    if let error = statuses.error {
-                        log.error("error trying to get post info to cache: \(error)")
-                    }
-                    stat = (statuses.value)
-                    if stat == nil {
-                        log.debug("going to return nil for \(url)")
-                        DispatchQueue.main.async {
-                            StatusCache.nilValuesURLsLock.lock()
-                            StatusCache.nilValueURLs.append(url)
-                            StatusCache.nilValuesURLsLock.unlock()
-                        }
-                    } else {
-                        DispatchQueue.main.async {
+            let request = Search.search(query: url.absoluteString, resolve: true)
+            Task {
+                do {
+                    let result = try await ClientService.runRequest(request: request)
+                    if let stat = result.statuses.first {
+                        await MainActor.run {
                             StatusCache.cachedStatusesLock.lock()
                             StatusCache.cachedStatuses[url] = stat
                             StatusCache.cachedStatusesLock.unlock()
                         }
+                        completion(url, stat)
+                    } else {
+                        completion(url, nil)
                     }
-                    completion(url, stat)
+                } catch {
+                    log.error("couldn't load post.")
+                    completion(url, nil)
                 }
             }
         }

--- a/Mammoth/Managers/StatusCache.swift
+++ b/Mammoth/Managers/StatusCache.swift
@@ -137,10 +137,11 @@ class StatusCache {
                         }
                         completion(url, stat)
                     } else {
+                        log.error("couldn't find quote post.")
                         completion(url, nil)
                     }
                 } catch {
-                    log.error("couldn't load post.")
+                    log.error("couldn't find quote post.")
                     completion(url, nil)
                 }
             }

--- a/Mammoth/Managers/StatusCache.swift
+++ b/Mammoth/Managers/StatusCache.swift
@@ -125,7 +125,7 @@ class StatusCache {
             return
         } else {
             // Make the network request, then the callback
-            let request = Search.search(query: url.absoluteString, resolve: true)
+            let request = Search.searchOne(query: url.absoluteString, resolve: true)
             Task {
                 do {
                     let result = try await ClientService.runRequest(request: request)

--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -995,7 +995,7 @@ extension PostCardModel {
 
         if let url = status.reblog?.quotePostCard()?.url ?? status.quotePostCard()?.url {
             // Remove quote post url from text
-            let regex = try! NSRegularExpression(pattern: "RE: <a[^>]*href=\"\(url)\"[^>]*>(?!.*<a[^>]*href=\"\(url)\"[^>]*>).*?</a>", options: .caseInsensitive)
+            let regex = try! NSRegularExpression(pattern: "RE:( )*<a[^>]*href=\"\(url)\"[^>]*>(?!.*<a[^>]*href=\"\(url)\"[^>]*>).*?</a>", options: .caseInsensitive)
             let range = NSMakeRange(0, text.count)
             text = regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "")
         }

--- a/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
@@ -265,6 +265,15 @@ extension Status {
                 // Create a card from this URL
                 quotePostCard = Card(url: firstURL.absoluteString, title: "", description: "", type: .link, authorName: "", authorUrl: "", providerName: "", html: "", width: 0, height: 0)
             }
+        } else if let hrefStart = text.range(of:"href=\"", options:.backwards) {
+            // old behaviour as a fallback, since ivory doesn't include a "RE: "
+            let urls = URLsFromHTML(String(text.suffix(from: hrefStart.lowerBound)))
+            if let firstURL = urls.first {
+                if firstURL.isPostURL() {
+                    // Create a card from this URL
+                    quotePostCard = Card(url: firstURL.absoluteString, title: "", description: "", type: .link, authorName: "", authorUrl: "", providerName: "", html: "", width: 0, height: 0)
+                }
+            }
         }
         
         return quotePostCard

--- a/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Status.swift
@@ -235,15 +235,12 @@ extension Status {
         
         let text = self.content
         
-        // If there is any link in this text, find the last link,
-        // and see if it's an @ URL.
-        //
         // Based on multiple case studies, our best algo is:
-        //      1. Find the position of the last "href="
+        //      1. Find the position of the last "RE:" or "From:"
         //      2. Get the first URL after that
-        //      3. See if the URL matches a post URL pattern
+        //      3. Assume the URL is a fediverse-compatible post
         
-        if let hrefStart = text.range(of:"href=\"", options:.backwards) {
+        if let quoteStart = text.range(of:"RE: ", options:.backwards) ?? text.range(of: "From: ") {
 
             // Make a link card from the content
             //
@@ -260,15 +257,13 @@ extension Status {
             // [0] = "https://mastodonapp.uk/@aarondavid/110300508837718942?public_follow=false"
             // [1] = "http://mastodonapp.uk/@aarondavid/110"
 
-            // Find the list of URLs, starting from where we found the href
-            let urls = URLsFromHTML(String(text.suffix(from: hrefStart.lowerBound)))
+            // Find the list of URLs, starting from the "RE:"
+            let urls = URLsFromHTML(String(text.suffix(from: quoteStart.lowerBound)))
             
-            // Use the first valid URL, and see if it looks like a quote post
+            // Use the first valid URL
             if let firstURL = urls.first {
-                if firstURL.isPostURL() {
-                    // Create a card from this URL
-                    quotePostCard = Card(url: firstURL.absoluteString, title: "", description: "", type: .link, authorName: "", authorUrl: "", providerName: "", html: "", width: 0, height: 0)
-                }
+                // Create a card from this URL
+                quotePostCard = Card(url: firstURL.absoluteString, title: "", description: "", type: .link, authorName: "", authorUrl: "", providerName: "", html: "", width: 0, height: 0)
             }
         }
         

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Search.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Search.swift
@@ -24,6 +24,16 @@ public struct Search {
         let method = HTTPMethod.get(.parameters(parameters))
         return Request<Results>(path: "/api/v2/search", method: method)
     }
+    
+    public static func searchOne(query: String, resolve: Bool? = nil) -> Request<Results> {
+        let parameters = [
+            Parameter(name: "q", value: query),
+            Parameter(name: "limit", value: "1"),
+            Parameter(name: "resolve", value: resolve.flatMap(trueOrNil))
+        ]
+        let method = HTTPMethod.get(.parameters(parameters))
+        return Request<Results>(path: "/api/v2/search", method: method)
+    }
 
     public static func searchAccounts(query: String, limit: Int? = nil, following: Bool? = nil) -> Request<Results
     > {


### PR DESCRIPTION
allows us to render every fediverse object as a quote post, rather than only mastodon stuff, also as a bonus makes quoting conform to the instance's moderation, since the user's instance fetches the post.

this is mainly a POC, currently incompatible with ivory because they just append the link under the post.

images: (can i make these smaller?)
![image](https://github.com/TheBLVD/mammoth/assets/65043391/7eadbd5a-a48a-4171-9180-f65644ebd668)
![image](https://github.com/TheBLVD/mammoth/assets/65043391/6a356f13-7c7a-4945-b9cd-92a198f50412)