### PR TITLE
MAM-4022-feed-stability-work

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
@@ -739,6 +739,8 @@ extension NewsFeedViewModel {
                     let newPostCard = postCard.mergeInOriginalData(status: status)
                     await MainActor.run { [weak self] in
                         guard let self else { return }
+                        guard !Task.isCancelled else { return }
+                        
                         self.update(with: .postCard(newPostCard), forType: self.type, silently: false)
                     }
                 }


### PR DESCRIPTION
Storing deferred snapshot updates in an array and executing them when scrolling ended was probably a bad design. When calling the deferred snapshot updates the scroll position was often not retained, which led to feed jumps.

In this PR, we don't store deferred snapshot updates but instead apply the latest snapshot changes once, when scrolling stops.

https://linear.app/theblvd/issue/MAM-4022/feed-stability-work