### PR TITLE
Update MastodonKit.

### DIFF
--- a/Mammoth.xcodeproj/project.pbxproj
+++ b/Mammoth.xcodeproj/project.pbxproj
@@ -777,6 +777,8 @@
 		D8DE092F2A3D12D800DD0483 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DE092E2A3D12D800DD0483 /* Haptics.swift */; };
 		F054D25C2B9C9E07006130A4 /* MetaTextKit in Frameworks */ = {isa = PBXBuildFile; productRef = F054D25B2B9C9E07006130A4 /* MetaTextKit */; };
 		F084802D2B8BBF02005201A7 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = F084802C2B8BBF02005201A7 /* Localizable.xcstrings */; };
+		F0ED082F2BB61DC00046B9EA /* RelationshipSeveranceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ED082E2BB61DC00046B9EA /* RelationshipSeveranceEvent.swift */; };
+		F0ED08312BB61F380046B9EA /* RelationshipSeveranceEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ED08302BB61F380046B9EA /* RelationshipSeveranceEventType.swift */; };
 		F0ED503C2B949A2C00F7525B /* MetaTextKit in Frameworks */ = {isa = PBXBuildFile; productRef = F0ED503B2B949A2C00F7525B /* MetaTextKit */; };
 		F0F6A5DD2ACCA9C1004FD05F /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F6A5DC2ACCA9C1004FD05F /* AnalyticsManager.swift */; };
 		F0F6A5DF2ACCB5D1004FD05F /* FeaturesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F6A5DE2ACCB5D1004FD05F /* FeaturesService.swift */; };
@@ -1609,6 +1611,8 @@
 		D8CA77602AB90D4000F49ECC /* ShareableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableViewController.swift; sourceTree = "<group>"; };
 		D8DE092E2A3D12D800DD0483 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		F084802C2B8BBF02005201A7 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		F0ED082E2BB61DC00046B9EA /* RelationshipSeveranceEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipSeveranceEvent.swift; sourceTree = "<group>"; };
+		F0ED08302BB61F380046B9EA /* RelationshipSeveranceEventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipSeveranceEventType.swift; sourceTree = "<group>"; };
 		F0F6A5DC2ACCA9C1004FD05F /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		F0F6A5DE2ACCB5D1004FD05F /* FeaturesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2168,6 +2172,8 @@
 				BFCC50A02B0D626A0081BFB5 /* ChannelOwner.swift */,
 				BF57C4042AE9C64000D11485 /* StatusSource.swift */,
 				BF57C4062AE9C7D600D11485 /* StatusSourceType.swift */,
+				F0ED082E2BB61DC00046B9EA /* RelationshipSeveranceEvent.swift */,
+				F0ED08302BB61F380046B9EA /* RelationshipSeveranceEventType.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3618,6 +3624,7 @@
 				C3F3B0292A4E29DC008FC4B7 /* NewsFeedViewModel+ScrollPositions.swift in Sources */,
 				53450E412936121600D720EA /* SwiftyGiphyGridLayout.swift in Sources */,
 				144DC6C72B14E20200F4EE98 /* GradientBorderView.swift in Sources */,
+				F0ED08312BB61F380046B9EA /* RelationshipSeveranceEventType.swift in Sources */,
 				C354D6042A0D1AF300F8AC04 /* ViewState.swift in Sources */,
 				53450E7E29361DA000D720EA /* ScheduledPostsViewController.swift in Sources */,
 				C354D6062A0D1B6E00F8AC04 /* RequestDelegate.swift in Sources */,
@@ -3872,6 +3879,7 @@
 				D8CA77612AB90D4000F49ECC /* ShareableViewController.swift in Sources */,
 				BF57C4012AE7130300D11485 /* ServerUpdatingCell.swift in Sources */,
 				C34413C42A1F53F900C3791F /* PostCardCell.swift in Sources */,
+				F0ED082F2BB61DC00046B9EA /* RelationshipSeveranceEvent.swift in Sources */,
 				BF0F3B9A2A82AFEB0055BB81 /* AnimatedTabBar.swift in Sources */,
 				BFA71B572AB3CBBB001D1EC1 /* InstanceManager.swift in Sources */,
 				533993E529141F4700560F83 /* SceneDelegate.swift in Sources */,

--- a/Mammoth/Services/Backend/MastodonKit/Models/Instance.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Instance.swift
@@ -40,6 +40,7 @@ public class Rules: Codable {
 public class PostConfiguration: Codable {
     public let statuses: PostConfigurationStatuses?
     public let urls: ConfigurationURLs?
+    public let vapid: ConfigurationVAPID?
 }
 
 public class PostConfigurationStatuses: Codable {
@@ -52,6 +53,13 @@ public class PostConfigurationStatuses: Codable {
 
 public class ConfigurationURLs: Codable {
     public let streaming: String?
+}
+
+public class ConfigurationVAPID: Codable {
+    public let publicKey: String?
+    private enum CodingKeys: String, CodingKey {
+        case publicKey = "public_key"
+    }
 }
 
 public class Usage: Codable {

--- a/Mammoth/Services/Backend/MastodonKit/Models/List.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/List.swift
@@ -13,15 +13,32 @@ public class List: Codable {
     public let id: String
     /// The Title of the list.
     public let title: String
+    /// Which replies should be shown in the list.
+    public let repliesPolicy: ListRepliesPolicy?
+    /// Whether members of this list need to get removed from the “Home” feed
+    public let exclusive: Bool?
     
-    public init(id: String, title: String) {
+    public init(id: String, title: String, repliesPolicy: ListRepliesPolicy = .none, exclusive: Bool = false) {
         self.id = id
         self.title = title
+        self.repliesPolicy = repliesPolicy
+        self.exclusive = exclusive
     }
     
     public init() {
         self.id = ""
         self.title = ""
+        self.repliesPolicy = .none
+        self.exclusive = false
     }
 
+}
+
+public enum ListRepliesPolicy: Codable {
+    /// Show replies to any followed user
+    case followed
+    /// Show replies to members of the list
+    case list
+    /// Show replies to no one
+    case none
 }

--- a/Mammoth/Services/Backend/MastodonKit/Models/Notification.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Notification.swift
@@ -19,6 +19,10 @@ public class Notificationt: Codable, Hashable {
     public let account: Account
     /// The Status associated with the notification, if applicable.
     public var status: Status?
+    /// Report that was the object of the notification. Attached when type of the notification is admin.report.
+    public let report: Report?
+    /// Summary of the event that caused follow relationships to be severed. Attached when type of the notification is severed_relationships.
+    public let relationshipSeveranceEvent: RelationshipSeveranceEvent?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -26,6 +30,8 @@ public class Notificationt: Codable, Hashable {
         case createdAt = "created_at"
         case account
         case status
+        case report
+        case relationshipSeveranceEvent = "relationship_severance_event"
     }
     
     public func hash(into hasher: inout Hasher) {
@@ -36,12 +42,16 @@ public class Notificationt: Codable, Hashable {
                 type: NotificationType,
                 createdAt: String,
                 account: Account,
-                status: Status? = nil) {
+                status: Status? = nil,
+                report: Report? = nil,
+                relationshipSeverance: RelationshipSeveranceEvent? = nil) {
         self.id = id
         self.type = type
         self.createdAt = createdAt
         self.account = account
         self.status = status
+        self.report = report
+        self.relationshipSeveranceEvent = relationshipSeverance
     }
 }
 

--- a/Mammoth/Services/Backend/MastodonKit/Models/NotificationType.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/NotificationType.swift
@@ -26,15 +26,23 @@ public enum NotificationType: String, Codable, CaseIterable {
     case update
     case follow_request
     
-//    case admin: NotificationTypeAdmin?
-}
-
-public enum NotificationTypeAdmin: String, Codable {
-    case adminSignup
-    case adminReport
+//  TODO: handle these notification types.
+//    case adminSignup
+//    case adminReport
+//    case severed_relationships
     
     private enum CodingKeys: String, CodingKey {
-        case adminSignup = "admin.sign_up"
-        case adminReport = "admin.report"
+        case mention
+        case reblog
+        case favourite
+        case follow
+        case direct
+        case poll
+        case status
+        case update
+        case follow_request
+//        case adminSignup = "admin.signup"
+//        case adminReport = "admin.report"
+//        case severed_relationships
     }
 }

--- a/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEvent.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEvent.swift
@@ -7,3 +7,26 @@
 //
 
 import Foundation
+
+public class RelationshipSeveranceEvent: Codable {
+    /// The ID of the relationship severance event in the database.
+    public let id: String
+    /// Type of event.
+    public let type: RelationshipSeveranceEventType
+    /// Whether the list of severed relationships is unavailable because the underlying issue has been purged.
+    public let purged: Bool
+    /// Name of the target of the moderation/block event. This is either a domain name or a user handle, depending on the event type.
+    public let targetName: String
+    /// Number of follow relationships (in either direction) that were severed.
+    public let relationshipsCount: Int?
+    /// When the event took place.
+    public let createdAt: String
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case purged
+        case targetName = "target_name"
+        case relationshipsCount = "relationships_count"
+        case createdAt = "created_at"
+    }
+}

--- a/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEvent.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEvent.swift
@@ -1,0 +1,9 @@
+//
+//  RelationshipSeveranceEvent.swift
+//  Mammoth
+//
+//  Created by Joey Despiuvas on 28/03/24
+//  Copyright © 2024 The BLVD. All rights reserved.
+//
+
+import Foundation

--- a/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEventType.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEventType.swift
@@ -7,3 +7,12 @@
 //
 
 import Foundation
+
+public enum RelationshipSeveranceEventType: String, Codable, CaseIterable {
+    /// A moderator suspended a whole domain
+    case domain_block
+    /// The user blocked a whole domain
+    case user_domain_block
+    ///A moderator suspended a specific account
+    case account_suspension
+}

--- a/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEventType.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/RelationshipSeveranceEventType.swift
@@ -1,0 +1,9 @@
+//
+//  RelationshipSeveranceEventType.swift
+//  Mammoth
+//
+//  Created by Joey Despiuvas on 28/03/24
+//  Copyright © 2024 The BLVD. All rights reserved.
+//
+
+import Foundation

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Accounts.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Accounts.swift
@@ -40,6 +40,8 @@ public struct Accounts {
                                          locked: Bool? = nil,
                                          bot: Bool? = nil,
                                          discoverable: Bool? = nil,
+                                         indexable: Bool? = nil,
+                                         hideCollections: Bool? = nil,
                                          sensitive: Bool? = nil,
                                          privacy: String? = nil,
                                          language: String? = nil,
@@ -55,7 +57,9 @@ public struct Accounts {
         let lockText = (locked ?? false) ? "true" : "false"
         let botText = (bot ?? false) ? "true" : "false"
         let discoverableText = (discoverable ?? false) ? "true" : "false"
+        let indexableText = (indexable ?? false) ? "true" : "false"
         let sensitiveText = (sensitive ?? false) ? "true" : "false"
+        let hideCollectionsText = (hideCollections ?? false) ? "true" : "false"
         
         var parameters = [
             Parameter(name: "display_name", value: displayName),
@@ -63,6 +67,8 @@ public struct Accounts {
             Parameter(name: "locked", value: lockText),
             Parameter(name: "bot", value: botText),
             Parameter(name: "discoverable", value: discoverableText),
+            Parameter(name: "indexable", value: indexableText),
+            Parameter(name: "hide_collections", value: hideCollectionsText),
             Parameter(name: "source[sensitive]", value: sensitiveText),
             Parameter(name: "source[privacy]", value: privacy),
             Parameter(name: "fields_attributes[0][name]", value: fieldName1),
@@ -312,8 +318,11 @@ public struct Accounts {
     ///
     /// - Parameter ids: The account's ids.
     /// - Returns: Request for `[Relationship]`.
-    public static func relationships(ids: [String]) -> Request<[Relationship]> {
-        let parameters = ids.map(toArrayOfParameters(withName: "id"))
+    public static func relationships(ids: [String], withSuspended: Bool = false) -> Request<[Relationship]> {
+        var parameters = [
+            Parameter(name: "with_suspended", value: String(withSuspended))
+        ]
+        parameters.append(contentsOf: ids.map(toArrayOfParameters(withName: "id")))
         let method = HTTPMethod.get(.parameters(parameters))
 
         return Request<[Relationship]>(path: "/api/v1/accounts/relationships", method: method)

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Lists.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Lists.swift
@@ -41,8 +41,11 @@ public struct Lists {
     ///
     /// - Parameter title: The title of the list.
     /// - Returns: Request for `List`.
-    public static func create(title: String) -> Request<List> {
-        let parameter = [Parameter(name: "title", value: title)]
+    public static func create(title: String, exclusive: Bool = false) -> Request<List> {
+        let parameter = [
+            Parameter(name: "title", value: title),
+            Parameter(name: "exclusive", value: String(exclusive))
+        ]
         let method = HTTPMethod.post(.parameters(parameter))
 
         return Request<List>(path: "/api/v1/lists", method: method)
@@ -54,8 +57,11 @@ public struct Lists {
     ///   - id: The list ID.
     ///   - title: The title of the list.
     /// - Returns: Request for `List`.
-    public static func update(id: String, title: String) -> Request<List> {
-        let parameter = [Parameter(name: "title", value: title)]
+    public static func update(id: String, title: String, exclusive: Bool = false) -> Request<List> {
+        let parameter = [
+            Parameter(name: "title", value: title),
+            Parameter(name: "exclusive", value: String(exclusive))
+        ]
         let method = HTTPMethod.put(.parameters(parameter))
 
         return Request<List>(path: "/api/v1/lists/\(id)", method: method)


### PR DESCRIPTION
some changes to comply with mastodon updates. 
you can use these to see some changes we'd have to do to the ui.

for example:
- `indexable` and `hide_collections` option in profile editor.
- `admin` and `severed_relationships` notifications support.
- lists `exclusive` option.