### PR TITLE
MAM-4099-unloaded-images-in-carousel-have-wrong-width

### DIFF
--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -112,9 +112,10 @@ extension PostCardMediaGallery {
                     let ratio = Double(media.meta?.small?.width ?? 16) / Double(media.meta?.small?.height ?? 9)
                     
                     let heightAnchor = image.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
-                    let widthAnchor = image.widthAnchor.constraint(equalTo: image.heightAnchor, multiplier: ratio)
                     heightAnchor.priority = .defaultHigh
                     heightAnchor.isActive = true
+                    let widthAnchor = image.widthAnchor.constraint(equalTo: image.heightAnchor, multiplier: ratio)
+                    widthAnchor.isActive = true
                 }
                 
                 if media.type == .video || media.type == .gifv || media.type == .audio {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -116,6 +116,7 @@ extension PostCardMediaGallery {
                     heightAnchor.isActive = true
                     let widthAnchor = image.widthAnchor.constraint(equalTo: image.heightAnchor, multiplier: ratio)
                     widthAnchor.isActive = true
+                    widthAnchor.priority = .defaultHigh
                 }
                 
                 if media.type == .video || media.type == .gifv || media.type == .audio {

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaGallery.swift
@@ -109,7 +109,10 @@ extension PostCardMediaGallery {
                     image.galleryDelegate = self
                     self.stackView.addArrangedSubview(image)
                     
+                    let ratio = Double(media.meta?.small?.width ?? 16) / Double(media.meta?.small?.height ?? 9)
+                    
                     let heightAnchor = image.heightAnchor.constraint(equalToConstant: PostCardMediaGalleryHeight)
+                    let widthAnchor = image.widthAnchor.constraint(equalTo: image.heightAnchor, multiplier: ratio)
                     heightAnchor.priority = .defaultHigh
                     heightAnchor.isActive = true
                 }


### PR DESCRIPTION
also removes the need for resizing blurhashes.