### PR TITLE
MAM-3914-dont-replace-every-post-data-when-fetching-for-interaction

### DIFF
--- a/Mammoth/Models/NewsFeedListItem.swift
+++ b/Mammoth/Models/NewsFeedListItem.swift
@@ -49,7 +49,7 @@ extension NewsFeedListItem {
     
     func extractData() -> Any? {
         if case .postCard(let postCard) = self {
-            let data = postCard.preSyncData ?? postCard.data
+            let data = postCard.data
             if case .mastodon(let status) = data  {
                 return status
             }

--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -178,22 +178,12 @@ final class PostCardModel {
     // Computed / dynamic properties
     
     var likeCount: String {
-        if let remote = remoteData {
-            switch remote {
-            case .mastodon(let status):
-                return PostCardModel.formattedLikeCount(status: status, withStaticMetrics: self.staticMetrics)
-                
-            case .bluesky(let postVM):
-                return (postVM.post.likeCount ?? 0).formatUsingAbbrevation()
-            }
-        } else {
-            switch data {
-            case .mastodon(let status):
-                return PostCardModel.formattedLikeCount(status: status, withStaticMetrics: self.staticMetrics)
-                
-            case .bluesky(let postVM):
-                return (postVM.post.likeCount ?? 0).formatUsingAbbrevation()
-            }
+        switch remoteData ?? data {
+        case .mastodon(let status):
+            return PostCardModel.formattedLikeCount(status: status, withStaticMetrics: self.staticMetrics)
+            
+        case .bluesky(let postVM):
+            return (postVM.post.likeCount ?? 0).formatUsingAbbrevation()
         }
     }
     
@@ -213,22 +203,12 @@ final class PostCardModel {
     }
     
     var replyCount: String {
-        if let remote = remoteData {
-            switch remote {
-            case .mastodon(let status):
-                return max((status.reblog?.repliesCount ?? status.repliesCount), 0).formatUsingAbbrevation()
-                
-            case .bluesky(let postVM):
-                return (postVM.post.replyCount ?? 0).formatUsingAbbrevation()
-            }
-        } else {
-            switch data {
-            case .mastodon(let status):
-                return max((status.reblog?.repliesCount ?? status.repliesCount), 0).formatUsingAbbrevation()
-                
-            case .bluesky(let postVM):
-                return (postVM.post.replyCount ?? 0).formatUsingAbbrevation()
-            }
+        switch remoteData ?? data {
+        case .mastodon(let status):
+            return max((status.reblog?.repliesCount ?? status.repliesCount), 0).formatUsingAbbrevation()
+            
+        case .bluesky(let postVM):
+            return (postVM.post.replyCount ?? 0).formatUsingAbbrevation()
         }
     }
     
@@ -243,22 +223,12 @@ final class PostCardModel {
     }
     
     var repostCount: String {
-        if let remote = remoteData {
-            switch remote {
-            case .mastodon(let status):
-                return PostCardModel.formattedRepostCount(status: status, withStaticMetrics: self.staticMetrics)
-                
-            case .bluesky(let postVM):
-                return (postVM.post.repostCount ?? 0).formatUsingAbbrevation()
-            }
-        } else {
-            switch data {
-            case .mastodon(let status):
-                return PostCardModel.formattedRepostCount(status: status, withStaticMetrics: self.staticMetrics)
-                
-            case .bluesky(let postVM):
-                return (postVM.post.repostCount ?? 0).formatUsingAbbrevation()
-            }
+        switch remoteData ?? data {
+        case .mastodon(let status):
+            return PostCardModel.formattedRepostCount(status: status, withStaticMetrics: self.staticMetrics)
+            
+        case .bluesky(let postVM):
+            return (postVM.post.repostCount ?? 0).formatUsingAbbrevation()
         }
     }
     
@@ -292,24 +262,16 @@ final class PostCardModel {
 
     var applicationName: String? {
         if let server = originalInstanceName {
-            if server == "www.threads.net" || server == "threads.net" {
+            if server == "www.threads.net" {
                 return "Threads"
             }
         }
-        if let remote = remoteData {
-            switch remote {
-            case .mastodon(let status):
-                return status.application?.name
-            case .bluesky:
-                return nil
-            }
-        } else {
-            switch data {
-            case .mastodon(let status):
-                return status.application?.name
-            case .bluesky:
-                return nil
-            }
+        
+        switch remoteData ?? data  {
+        case .mastodon(let status):
+            return status.application?.name
+        case .bluesky:
+            return nil
         }
     }
     

--- a/Mammoth/Services/Backend/StatusService.swift
+++ b/Mammoth/Services/Backend/StatusService.swift
@@ -17,7 +17,7 @@ struct StatusService {
     }
     
     static func like(postCard: PostCardModel, withPolicy fetchPolicy: FetchPolicy = FetchPolicy.regular) async throws -> PostCardModel? {
-        switch postCard.preSyncData ?? postCard.data {
+        switch postCard.data {
         case .mastodon(let status):
             switch(fetchPolicy) {
             case .regular:
@@ -61,7 +61,7 @@ struct StatusService {
     }
     
     static func unlike(postCard: PostCardModel, withPolicy fetchPolicy: FetchPolicy = FetchPolicy.regular) async throws -> PostCardModel? {
-        switch postCard.preSyncData ?? postCard.data {
+        switch postCard.data {
         case .mastodon(let status):
             switch(fetchPolicy) {
             case .regular:

--- a/Mammoth/Utils/PostActions.swift
+++ b/Mammoth/Utils/PostActions.swift
@@ -313,7 +313,7 @@ extension PostActions {
     
     // Handler call when pressing the reply button on a post
     static func onReply(target: UIViewController, postCard: PostCardModel) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         let vc = NewPostViewController()
         vc.isModalInPresentation = true
@@ -427,7 +427,7 @@ extension PostActions {
     
     // Handler call when pressing the bookmark button on a post
     static func onBookmark(postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         if let uniqueId = postCard.uniqueId {
             // Optimistically update local cache
@@ -456,7 +456,7 @@ extension PostActions {
     
     // Handler call when pressing the unbookmark button on a post
     static func onUnbookmark(postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         if let uniqueId = postCard.uniqueId {
             // Optimistically update local cache
@@ -484,7 +484,7 @@ extension PostActions {
     }
     
     static func onEditPost(target: UIViewController, postCard: PostCardModel) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         triggerHapticImpact(style: .light)
         
@@ -496,7 +496,7 @@ extension PostActions {
     }
     
     static func onDeletePost(target: UIViewController, postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         let alert = UIAlertController(title: nil, message: NSLocalizedString("post.delete.confirm", comment: ""), preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: NSLocalizedString("generic.delete", comment: ""), style: .destructive , handler:{ (UIAlertAction) in
@@ -536,7 +536,7 @@ extension PostActions {
     
     // Handler call when pressing the pin post button on a post
     static func onPinPost(target: UIViewController, postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         triggerHaptic3Notification()
         
         // HTTP request
@@ -561,7 +561,7 @@ extension PostActions {
     
     // Handler call when pressing the unpin post button on a post
     static func onUnpinPost(target: UIViewController, postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         triggerHaptic3Notification()
 
@@ -581,7 +581,7 @@ extension PostActions {
     }
     
     static func onShare(target: UIViewController, postCard: PostCardModel) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         let text = URL(string: "\(status.reblog?.url ?? status.url ?? "")")!
         self.onShare(target: target, url: text)
@@ -595,7 +595,7 @@ extension PostActions {
     }
     
     static func onViewInBrowser(postCard: PostCardModel) {
-        guard case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard case .mastodon(let status) = postCard.data else { return }
         
         if let str = status.reblog?.url ?? status.url {
             if let url = URL(string: str) {
@@ -976,7 +976,7 @@ extension PostActions {
     }
     
     static func report(postCard: PostCardModel, withFetchPolicy fetchPolicy: StatusService.FetchPolicy = .retryLocally) {
-        guard let accountID = postCard.account?.id, case .mastodon(let status) = postCard.preSyncData ?? postCard.data else { return }
+        guard let accountID = postCard.account?.id, case .mastodon(let status) = postCard.data else { return }
         
         let alert = UIAlertController(title: NSLocalizedString("post.report.title", comment: ""), message: NSLocalizedString("post.report.text", comment: ""), preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: NSLocalizedString("post.report", comment: ""), style: .destructive , handler:{ (UIAlertAction) in


### PR DESCRIPTION
i basically inverted our logic. instead of overwriting the `.data` parameter and keeping a backup in `.preSyncData`, i'm keeping `.data` the original data and only writing new data to `.remoteData`, which is only used for interactions and app name.

i think this is a good quick fix for weird ID behavior until we figure out a better solution.