### PR TITLE
Update reply icon and reorder items

### DIFF
--- a/Mammoth/Models/PostCardTypes.swift
+++ b/Mammoth/Models/PostCardTypes.swift
@@ -53,7 +53,7 @@ enum PostCardButtonType: Int {
     func icon(symbolConfig: UIImage.SymbolConfiguration?) -> UIImage? {
         switch(self) {
         case .reply:
-            return FontAwesome.image(fromChar: "\u{f075}", size: 16, weight: .regular)
+            return FontAwesome.image(fromChar: "\u{f3e5}", size: 16, weight: .regular)
         case .repost:
             return FontAwesome.image(fromChar: "\u{f361}", size: 16, weight: .regular)
         case .like:

--- a/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardFooter.swift
@@ -67,10 +67,10 @@ private extension PostCardFooter {
             mainStackView.trailingAnchor.constraint(equalTo: self.layoutMarginsGuide.trailingAnchor),
         ])
         
-        mainStackView.addArrangedSubview(likeButton)
         mainStackView.addArrangedSubview(replyButton)
-        mainStackView.addArrangedSubview(repostButton)
         mainStackView.addArrangedSubview(quoteButton)
+        mainStackView.addArrangedSubview(repostButton)
+        mainStackView.addArrangedSubview(likeButton)
         mainStackView.addArrangedSubview(moreButton)
     }
 }


### PR DESCRIPTION
I struggled at first trying to reply to posts. I think part of that was the icon and its location in the items. I've updated the icon for replies and reordered the footer items based on what the user will likely need first.

New Order:
<img width="360" alt="Screenshot 2024-06-18 at 3 55 43 PM" src="https://github.com/TheBLVD/mammoth/assets/644761/3ef9d0cc-428e-458b-b798-85b864d03276">

Old Order:
![IMG_F67E5317D52C-1](https://github.com/TheBLVD/mammoth/assets/644761/04baeef9-0060-4f41-9d0c-84a4a4b15879)
