### PR TITLE
Add haptics for home menu items

### DIFF
--- a/Mammoth/Screens/HomeScreen/HomeViewController.swift
+++ b/Mammoth/Screens/HomeScreen/HomeViewController.swift
@@ -332,24 +332,28 @@ extension HomeViewController {
         let jumpToMenu = UIMenu(title: NSLocalizedString("home.jumpToAList", comment: "Appears when holding in the 'home' button, before a list of feeds."), options: [.displayInline], children: FeedsManager.shared.feeds.sorted(by: { (_, right) in !right.isEnabled }).map { item in
             return UIAction(title: item.type.plainTitle(), image: item.type.icon, identifier: nil) { [weak self] _ in
                 guard let self else { return }
-                
-                if item.isEnabled {
-                    if let index = self.indexOfCarouselItem(item: item.type) {
-                        self.feedCarousel.scrollTo(index: index)
-                        self.carouselItemPressed(withIndex: index)
+
+                DispatchQueue.main.async {
+                    triggerHapticImpact(style: .light)
+
+                    if item.isEnabled {
+                        if let index = self.indexOfCarouselItem(item: item.type) {
+                            self.feedCarousel.scrollTo(index: index)
+                            self.carouselItemPressed(withIndex: index)
+                        }
+
+                        if self.navigationController?.parent != nil {
+                            self.navigationController?.popToRootViewController(animated: true)
+                        }
+                    } else {
+                        let feedView = NewsFeedViewController(type: item.type)
+                        self.navigationController?.pushViewController(feedView, animated: true)
                     }
-                    
-                    if self.navigationController?.parent != nil {
-                        self.navigationController?.popToRootViewController(animated: true)
+
+                    // Navigate to home if needed
+                    if let currentTabBarController = getTabBarController(), currentTabBarController.selectedIndex != 0 {
+                        currentTabBarController.selectedIndex = 0
                     }
-                } else {
-                    let feedView = NewsFeedViewController(type: item.type)
-                    self.navigationController?.pushViewController(feedView, animated: true)
-                }
-                
-                // Navigate to home if needed
-                if let currentTabBarController = getTabBarController(), currentTabBarController.selectedIndex != 0 {
-                    currentTabBarController.selectedIndex = 0
                 }
             }
         })

--- a/Mammoth/Views/AccountSwitcherButton.swift
+++ b/Mammoth/Views/AccountSwitcherButton.swift
@@ -110,6 +110,7 @@ class AccountSwitcherButton: UIButton {
             let accountAction = UIAction(title: "@\(item.fullAcct)", image: isSelected ? FontAwesome.image(fromChar: "\u{f00c}", size: 16, weight: .bold).withRenderingMode(.alwaysTemplate) : nil, identifier: nil) { action in
                 // switch account
                 DispatchQueue.main.async {
+                    triggerHapticImpact(style: .light)
                     let account = item
                     // Only switch if not already the current account
                     if account.uniqueID != AccountsManager.shared.currentAccount?.uniqueID {


### PR DESCRIPTION
I don't have a way to test this at the moment since you need developer account access to add physical devices. I think this is the right change based on what I found in the other context menu items.

I added haptic impact light to the home menu items as well as a missing one from the profile context menu. There were also a few lines of spaces cleaned up. Otherwise, minor changes here. Please let me know if this is every spot for this. I'm trying to have a small feedback when the long press presents this menu:

<img width="404" alt="Screenshot 2024-06-20 at 7 35 17 PM" src="https://github.com/TheBLVD/mammoth/assets/644761/826fa3e6-9b81-4321-a177-511cd621a87a">

It already presents a feedback only when tapping the Add account button. I added one for changing accounts here:

<img width="412" alt="Screenshot 2024-06-20 at 7 36 21 PM" src="https://github.com/TheBLVD/mammoth/assets/644761/736a0fad-c6aa-46f2-afe7-465f9050a9e3">

If I'm missing one, which I think I might be, let me know and I can update to add it in the correct spot.