### PR TITLE
Missing Usertag Value Localization

### DIFF
--- a/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/AppearanceSettingsViewController.swift
@@ -369,14 +369,11 @@ class AppearanceSettingsViewController: UIViewController, UITableViewDataSource,
                 cell.accessibilityLabel = NSLocalizedString("settings.appearance.names", comment: "")
                 
                 cell.imageView?.image = settingsFontAwesomeImage("\u{f5b7}")
-                if GlobalStruct.displayName == .full {
-                    cell.detailTextLabel?.text = NSLocalizedString("settings.appearance.names.full", comment: "")
-                } else if GlobalStruct.displayName == .usernameOnly {
-                    cell.detailTextLabel?.text = NSLocalizedString("settings.appearance.names.username", comment: "")
-                } else if GlobalStruct.displayName == .usertagOnly {
-                    cell.detailTextLabel?.text = NSLocalizedString("generic.none", comment: "")
-                } else {
-                    cell.detailTextLabel?.text = "None" // .none
+                cell.detailTextLabel?.text = switch GlobalStruct.displayName {
+                case .full:         NSLocalizedString("settings.appearance.names.full", comment: "")
+                case .usernameOnly: NSLocalizedString("settings.appearance.names.username", comment: "")
+                case .usertagOnly:  NSLocalizedString("settings.appearance.names.usertag", comment: "")
+                case .none:         NSLocalizedString("generic.none", comment: "")
                 }
                 
                 var gestureActions: [UIAction] = []


### PR DESCRIPTION
Fixed an issue where the usertag localization was not being used when the value was set.

### Before

<img width="392" alt="image" src="https://github.com/TheBLVD/mammoth/assets/225505/1371eaec-46af-4291-9f2c-9018a874a2d3">

### After

<img width="390" alt="image" src="https://github.com/TheBLVD/mammoth/assets/225505/2c37f126-00a5-4d0a-b71a-2343c225f0ce">
