### PR TITLE
Full Width Post Fixes

### DIFF
--- a/Mammoth/Localizable.xcstrings
+++ b/Mammoth/Localizable.xcstrings
@@ -60578,7 +60578,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Media size"
+            "value" : "Media & content size"
           }
         },
         "es" : {
@@ -60711,6 +60711,17 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        }
+      }
+    },
+    "settings.appearance.mediaSize.fullWidth" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full width"
           }
         }
       }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -551,10 +551,6 @@ private extension PostCardCell {
         wrapperStackView.addArrangedSubview(headerExtension)
         wrapperStackView.addArrangedSubview(mainStackView)
         
-        if self.headerExtension == nil {
-            self.headerExtension = PostCardHeaderExtension()
-        }
-        
         NSLayoutConstraint.activate([
             wrapperStackView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             wrapperStackView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),

--- a/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardCell.swift
@@ -642,7 +642,6 @@ private extension PostCardCell {
             
             self.contentStackView.addArrangedSubview(self.mediaContainer)
             
-            // TODO: Make sure this happens on iPad and Mac as well when we don't use the sidebar buttons, ie. when the app is in split view.
             if UIDevice.current.userInterfaceIdiom == .phone || self.cellVariant.mediaVariant == .fullWidth {
                 let trailingConstraint = self.mediaContainer.trailingAnchor.constraint(equalTo: self.contentStackView.trailingAnchor)
                 trailingConstraint.isActive = true
@@ -939,10 +938,12 @@ extension PostCardCell {
         self.configureMetaTextContent()
         
         if self.cellVariant.hasMedia {
+            var isDisplayingMedia = false
             
             if type != .detail && postCard.hasMediaAttachment && !postCard.mediaAttachmentDescription.isEmpty {
                 self.hiddenImageIndicator.text = postCard.mediaAttachmentDescription
                 self.hiddenImageIndicator.isHidden = false
+                isDisplayingMedia = true
             } else {
                 self.hiddenImageIndicator.isHidden = true
             }
@@ -952,6 +953,7 @@ extension PostCardCell {
                 self.poll?.prepareForReuse()
                 self.poll?.configure(postCard: postCard)
                 self.poll?.isHidden = false
+                isDisplayingMedia = true
             } else {
                 self.poll?.isHidden = true
             }
@@ -961,6 +963,7 @@ extension PostCardCell {
                 self.quotePost?.configure(postCard: postCard)
                 self.quotePost?.onPress = onButtonPress
                 self.quotePost?.isHidden = false
+                isDisplayingMedia = true
             } else {
                 self.quotePost?.isHidden = true
             }
@@ -970,6 +973,7 @@ extension PostCardCell {
                 self.linkPreview?.configure(postCard: postCard)
                 self.linkPreview?.onPress = onButtonPress
                 self.linkPreview?.isHidden = false
+                isDisplayingMedia = true
             } else {
                 self.linkPreview?.isHidden = true
             }
@@ -980,6 +984,7 @@ extension PostCardCell {
                     self.webview?.configure(postCard: postCard)
                     self.webview?.isHidden = false
                 }
+                isDisplayingMedia = true
             } else {
                 self.webview?.isHidden = true
             }
@@ -988,6 +993,7 @@ extension PostCardCell {
             if postCard.hasMediaAttachment && postCard.mediaDisplayType == .singleImage && !postCard.hasWebview {
                 self.image?.configure(postCard: postCard)
                 self.image?.isHidden = false
+                isDisplayingMedia = true
             } else {
                 self.image?.isHidden = true
             }
@@ -1009,6 +1015,7 @@ extension PostCardCell {
                     
                     self.video?.isHidden = false
                 }
+                isDisplayingMedia = true
             } else {
                 self.video?.isHidden = true
             }
@@ -1024,10 +1031,14 @@ extension PostCardCell {
                     self.mediaGallery?.isHidden = false
                     self.mediaStack?.isHidden = true
                 }
-                
+                isDisplayingMedia = true
             } else {
                 self.mediaGallery?.isHidden = true
                 self.mediaStack?.isHidden = true
+            }
+            
+            if self.cellVariant.mediaVariant == .fullWidth {
+                self.contentStackView.setCustomSpacing(isDisplayingMedia ? 12.0 : 0.0, after: self.textAndSmallMediaStackView)
             }
         }
         


### PR DESCRIPTION
Re-introduced localized strings, and fixed an issue where there was too much space after posts with no media in full width mode.

<img width="559" alt="image" src="https://github.com/TheBLVD/mammoth/assets/225505/58dce732-96fa-4e6f-952a-c522ac757a70">
