### PR TITLE
MAM-4155: Allow all 2xx status codes to be recognized as success

### DIFF
--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -817,10 +817,9 @@ extension PostCardModel {
     func preloadVideo() {
         if GlobalStruct.autoPlayVideos {
             // Don't attempt to preload videos that haven't finished processing. It would only have a previewURL that's just an image and won't be useful anyways
-            if self.videoPlayer == nil, let media = self.mediaAttachments.first, media.url != nil {
+            if self.videoPlayer == nil, let media = self.mediaAttachments.first, let mediaURLString = media.url, let videoURL = URL(string: mediaURLString) {
                 DispatchQueue.global(qos: .default).async {
-                    let videoURL = URL(string: media.url!)
-                    let playerItem = AVPlayerItem(url: videoURL!)
+                    let playerItem = AVPlayerItem(url: videoURL)
                     let player = AVPlayer(playerItem: playerItem)
                     player.isMuted = true
                     DispatchQueue.main.async {

--- a/Mammoth/Models/PostCardModel.swift
+++ b/Mammoth/Models/PostCardModel.swift
@@ -816,9 +816,11 @@ extension PostCardModel {
     
     func preloadVideo() {
         if GlobalStruct.autoPlayVideos {
-            if self.videoPlayer == nil, let media = self.mediaAttachments.first, let videoURL = URL(string: media.url) {
+            // Don't attempt to preload videos that haven't finished processing. It would only have a previewURL that's just an image and won't be useful anyways
+            if self.videoPlayer == nil, let media = self.mediaAttachments.first, media.url != nil {
                 DispatchQueue.global(qos: .default).async {
-                    let playerItem = AVPlayerItem(url: videoURL)
+                    let videoURL = URL(string: media.url!)
+                    let playerItem = AVPlayerItem(url: videoURL!)
                     let player = AVPlayer(playerItem: playerItem)
                     player.isMuted = true
                     DispatchQueue.main.async {

--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -402,7 +402,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
 
                             self.mediaIdStrings.append(stat.mediaAttachments[index].id)
                             if stat.mediaAttachments[index].type == .video || stat.mediaAttachments[index].type == .gifv {
-                                if let ur = URL(string: stat.mediaAttachments[index].url) {
+                                if let ur = URL(string: stat.mediaAttachments[index].url ?? stat.mediaAttachments[index].previewURL!) {
                                     self.videoAttached = true
                                     self.vUrl = ur
                                     self.tryDisplayThumbnail(url: self.vUrl)
@@ -419,14 +419,14 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
                                 }, completion: { x in
                                     
                                 })
-                                if let ur = URL(string: stat.mediaAttachments[0].url) {
+                                if let ur = URL(string: stat.mediaAttachments[0].url ?? stat.mediaAttachments[0].previewURL!) {
                                     self.audioAttached = true
                                     self.videoAttached = false
                                     self.vUrl = ur
                                     self.createToolbar()
                                 }
                             } else {
-                                self.imageButton[index].sd_setImage(with: URL(string: stat.mediaAttachments[index].url), for: .normal)
+                                self.imageButton[index].sd_setImage(with: URL(string: stat.mediaAttachments[index].url ?? stat.mediaAttachments[index].previewURL!), for: .normal)
                             }
                             if stat.mediaAttachments[index].type == .gifv {
                                 self.videoAttached = false

--- a/Mammoth/Services/Backend/MastodonKit/Client.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Client.swift
@@ -87,7 +87,7 @@ public class Client: NSObject, ClientType, URLSessionTaskDelegate {
                 
                 guard
                     let httpResponse = response as? HTTPURLResponse,
-                    httpResponse.statusCode == 200
+                    httpResponse.statusCode >= 200 && httpResponse.statusCode < 300
                 else {
                     log.error("error in response/status from: \(url)")
                     let statusCode = (response as? HTTPURLResponse)?.statusCode

--- a/Mammoth/Services/Backend/MastodonKit/Models/Attachment.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Models/Attachment.swift
@@ -14,7 +14,7 @@ public class Attachment: Codable, Equatable {
     /// Type of the attachment.
     public let type: AttachmentType
     /// URL of the locally hosted version of the image.
-    public let url: String
+    public let url: String?
     /// For remote images, the remote URL of the original image.
     public let remoteURL: String?
     /// URL of the preview image.

--- a/Mammoth/Views/Cells/DetailImageView.swift
+++ b/Mammoth/Views/Cells/DetailImageView.swift
@@ -404,7 +404,7 @@ class DetailImageView: UIView, UICollectionViewDataSource, UICollectionViewDeleg
                 if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCellD {
                     if let originImage = cell.image.image {
                         for x in self.imagesFull {
-                            let photo = SKPhoto.photoWithImageURL(x.url)
+                            let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                             photo.shouldCachePhotoURLImage = true
                             images.append(photo)
                         }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImage.swift
@@ -371,7 +371,7 @@ final class PostCardImage: UIView {
             // Open fullscreen image preview
             let images = self.postCard?.mediaAttachments.compactMap { attachment in
                 guard attachment.type == .image else { return SKPhoto() }
-                let photo = SKPhoto.photoWithImageURL(attachment.url)
+                let photo = SKPhoto.photoWithImageURL(attachment.url ?? attachment.previewURL!)
                 photo.contentMode = imageView.contentMode
                 photo.shouldCachePhotoURLImage = false
                 
@@ -410,11 +410,11 @@ final class PostCardImage: UIView {
             PostCardModel.imageDecodeQueue.async { [weak self] in
                 guard let self else { return }
                 let prefetcher = SDWebImagePrefetcher.shared
-                let urls = self.postCard?.mediaAttachments.compactMap { URL(string: $0.url) }
+                let urls = self.postCard?.mediaAttachments.compactMap { URL(string: $0.url ?? $0.previewURL!) }
                 prefetcher.prefetchURLs(urls, progress: nil) { _, _ in
                     let images = self.postCard?.mediaAttachments.compactMap { attachment in
                         guard attachment.type == .image else { return nil }
-                        let photo = SKPhoto.photoWithImageURL(attachment.url)
+                        let photo = SKPhoto.photoWithImageURL(attachment.url ?? attachment.previewURL!)
                         photo.contentMode = self.imageView.contentMode
                         photo.shouldCachePhotoURLImage = false
                         photo.underlyingImage = SDImageCache.shared.imageFromCache(forKey: attachment.url)

--- a/Mammoth/Views/Cells/PostCardCell/PostCardImageAttachment.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardImageAttachment.swift
@@ -202,7 +202,7 @@ extension PostCardImageAttachment: UICollectionViewDataSource {
         
         if model.usesMediaPlayer {
             // Open fullscreen video player
-            let mediaURLString = model.mediaAttachment.url
+            let mediaURLString = model.mediaAttachment.url ?? model.mediaAttachment.previewURL!
             
             if let mediaURL = URL(string: mediaURLString) {
                 let player = AVPlayer(url: mediaURL)
@@ -218,7 +218,7 @@ extension PostCardImageAttachment: UICollectionViewDataSource {
         } else {
             // Open fullscreen image preview
             let images = self.mediaAttachments.map { attachment in
-                let photo = SKPhoto.photoWithImageURL(attachment.url)
+                let photo = SKPhoto.photoWithImageURL(attachment.url ?? attachment.previewURL!)
                 photo.shouldCachePhotoURLImage = true
                 return photo
             }

--- a/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardMediaStack.swift
@@ -160,7 +160,7 @@ final class PostCardMediaStack: UIView {
             // Open fullscreen image preview
             let images = self.postCard?.mediaAttachments.compactMap { attachment in
                 guard attachment.type == .image else { return SKPhoto() }
-                let photo = SKPhoto.photoWithImageURL(attachment.url)
+                let photo = SKPhoto.photoWithImageURL(attachment.url ?? attachment.previewURL!)
                 photo.shouldCachePhotoURLImage = false
                 
                 let imageFromCache = SDImageCache.shared.imageFromCache(forKey: attachment.url)
@@ -196,11 +196,11 @@ final class PostCardMediaStack: UIView {
             PostCardModel.imageDecodeQueue.async { [weak self] in
                 guard let self else { return }
                 let prefetcher = SDWebImagePrefetcher.shared
-                let urls = self.postCard?.mediaAttachments.compactMap { URL(string: $0.url) }
+                let urls = self.postCard?.mediaAttachments.compactMap { URL(string: $0.url ?? $0.previewURL!) }
                 prefetcher.prefetchURLs(urls, progress: nil) { _, _ in
                     let images = self.postCard?.mediaAttachments.compactMap { attachment in
                         guard attachment.type == .image else { return nil }
-                        let photo = SKPhoto.photoWithImageURL(attachment.url)
+                        let photo = SKPhoto.photoWithImageURL(attachment.url ?? attachment.previewURL!)
                         photo.shouldCachePhotoURLImage = false
                         photo.underlyingImage = SDImageCache.shared.imageFromCache(forKey: attachment.url)
                         return photo

--- a/Mammoth/Views/Cells/PostCardCell/PostCardVideo.swift
+++ b/Mammoth/Views/Cells/PostCardCell/PostCardVideo.swift
@@ -451,7 +451,7 @@ final class PostCardVideo: UIView {
             guard self.media != media else { return }
             
             self.media = media
-            if let videoURL = URL(string: media.remoteURL ?? media.url) {
+            if let videoURL = URL(string: media.remoteURL ?? media.url ?? media.previewURL!) {
                 
                 loadingIndicator.startAnimating()
                 

--- a/Mammoth/Views/Cells/PostView.swift
+++ b/Mammoth/Views/Cells/PostView.swift
@@ -2829,7 +2829,7 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
                     if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCell {
                         if let originImage = cell.image.image {
                             for x in self.imagesFull {
-                                let photo = SKPhoto.photoWithImageURL(x.url)
+                                let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                                 photo.shouldCachePhotoURLImage = true
                                 images.append(photo)
                             }
@@ -2854,7 +2854,7 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
                     if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCellActivity {
                         if let originImage = cell.image.image {
                             for x in self.imagesFull {
-                                let photo = SKPhoto.photoWithImageURL(x.url)
+                                let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                                 photo.shouldCachePhotoURLImage = true
                                 images.append(photo)
                             }
@@ -2879,7 +2879,7 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
                     if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCellS {
                         if let originImage = cell.image.image {
                             for x in self.imagesFull {
-                                let photo = SKPhoto.photoWithImageURL(x.url)
+                                let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                                 photo.shouldCachePhotoURLImage = true
                                 images.append(photo)
                             }
@@ -2904,7 +2904,7 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
                     if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCell2 {
                         if let originImage = cell.image.image {
                             for x in self.imagesFull {
-                                let photo = SKPhoto.photoWithImageURL(x.url)
+                                let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                                 photo.shouldCachePhotoURLImage = true
                                 images.append(photo)
                             }
@@ -2929,7 +2929,7 @@ class PostView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, SK
                     if let cell = self.collectionView1.cellForItem(at: indexPath) as? CollectionImageCell3 {
                         if let originImage = cell.image.image {
                             for x in self.imagesFull {
-                                let photo = SKPhoto.photoWithImageURL(x.url)
+                                let photo = SKPhoto.photoWithImageURL(x.url ?? x.previewURL!)
                                 photo.shouldCachePhotoURLImage = true
                                 images.append(photo)
                             }


### PR DESCRIPTION
This fixes MAM-4155 (#593), with a further followup after merging at MAM-4159