### PR TITLE
MAM-4161-hide-reader-view-option-when-using-external-browser

### DIFF
--- a/Mammoth/AppDelegate.swift
+++ b/Mammoth/AppDelegate.swift
@@ -229,7 +229,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         GlobalStruct.scrollDirectionDown = UserDefaults.standard.value(forKey: "scrollDirectionDown") as? Bool ?? true
         GlobalStruct.openLinksInBrowser = UserDefaults.standard.value(forKey: "openLinksInBrowser") as? Bool ?? false
         GlobalStruct.openLinksInReaderView = UserDefaults.standard.value(forKey: "openLinksInReaderView") as? Bool ?? false
-        GlobalStruct.preferredBrowser = UserDefaults.standard.string(forKey: "PreferredBrowser") ?? "Safari"
+        GlobalStruct.preferredBrowser = UserDefaults.standard.string(forKey: "PreferredBrowser") ?? "In-app browser"
         GlobalStruct.appLock = UserDefaults.standard.value(forKey: "appLock") as? Bool ?? false
         GlobalStruct.shareAnalytics = UserDefaults.standard.value(forKey: "shareAnalytics") as? Bool ?? true
         

--- a/Mammoth/Models/GlobalStruct.swift
+++ b/Mammoth/Models/GlobalStruct.swift
@@ -151,7 +151,7 @@ public struct GlobalStruct {
     static var scrollDirectionDown: Bool = true
     static var openLinksInBrowser: Bool = false
     static var openLinksInReaderView: Bool = false
-    static var preferredBrowser: String = "Safari"
+    static var preferredBrowser: String = "In-app browser"
     static var appLock: Bool = false
     static var shareAnalytics: Bool = true
     

--- a/Mammoth/Screens/Settings/OpenLinksSettingsViewController.swift
+++ b/Mammoth/Screens/Settings/OpenLinksSettingsViewController.swift
@@ -8,8 +8,13 @@
 
 import UIKit
 
+protocol OpenLinksSettingsViewDelegate: AnyObject {
+    func didChangeBrowserSettings()
+}
+
 class OpenLinksSettingsViewController: UITableViewController {
 
+    weak var delegate: OpenLinksSettingsViewDelegate?
     var browsers: [String] = []
     let userDefaultsKey = "PreferredBrowser"
     
@@ -69,7 +74,7 @@ class OpenLinksSettingsViewController: UITableViewController {
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.text = browsers[indexPath.row]
         
-        let preferredBrowser = UserDefaults.standard.string(forKey: userDefaultsKey)
+        let preferredBrowser = GlobalStruct.preferredBrowser
         if browsers[indexPath.row] == preferredBrowser {
             cell.accessoryType = .checkmark
         } else {
@@ -92,6 +97,7 @@ class OpenLinksSettingsViewController: UITableViewController {
         UserDefaults.standard.set(selectedBrowser, forKey: userDefaultsKey.value)
         GlobalStruct.preferredBrowser = selectedBrowser
         tableView.reloadData()
+        self.delegate?.didChangeBrowserSettings()
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {

--- a/Mammoth/Screens/Settings/SettingsViewController.swift
+++ b/Mammoth/Screens/Settings/SettingsViewController.swift
@@ -37,9 +37,9 @@ class SettingsViewController: UIViewController {
                 ].compactMap{$0}),
                 SettingsSection(items: [
                     .openLinks,
-                    .readerView,
+                    GlobalStruct.preferredBrowser == "In-app browser" ? .readerView : nil,
                     .appLock
-                ]),
+                ].compactMap{$0}),
                 SettingsSection(items: [
                     .getInTouch,
                     .subscriptions,
@@ -67,9 +67,9 @@ class SettingsViewController: UIViewController {
                 ].compactMap{$0}),
                 SettingsSection(items: [
                     .openLinks,
-                    .readerView,
+                    GlobalStruct.preferredBrowser == "In-app browser" ? .readerView : nil,
                     .appLock
-                ]),
+                ].compactMap{$0}),
                 SettingsSection(items: [
                     .getInTouch,
                     .development
@@ -371,6 +371,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
             postClearCacheAlert()
         case .openLinks:
             vc = OpenLinksSettingsViewController()
+            (vc as! OpenLinksSettingsViewController).delegate = self
         default:
             vc = nil
         }
@@ -464,5 +465,11 @@ internal extension SettingsViewController {
              }
          }
          self.reloadAll()
+    }
+}
+
+extension SettingsViewController: OpenLinksSettingsViewDelegate {
+    func didChangeBrowserSettings() {
+        self.reloadAll()
     }
 }

--- a/Mammoth/Utils/LinkOpener.swift
+++ b/Mammoth/Utils/LinkOpener.swift
@@ -61,7 +61,7 @@ enum LinkOpener: String, CaseIterable {
     var title: String {
         switch self {
         case .safari: return "System Default"
-        case .mammoth: return "Mammoth"
+        case .mammoth: return "In-app browser"
         case .brave: return "Brave"
         case .chrome: return "Chrome"
         case .duckDuckGo: return "DuckDuckGo"


### PR DESCRIPTION
- renaming browser option "Mammoth" to "In-app browser"
- only showing "reader view" option when "In-app browser" is being used
- making "in-app browser" the default