### PR TITLE
MAM-4167: Add export compliance key 

### DIFF
--- a/Mammoth/Info.plist
+++ b/Mammoth/Info.plist
@@ -1165,5 +1165,7 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
To stop app store connect from bugging every time