### PR TITLE
Revert to v1 account search api for autocomplete only

### DIFF
--- a/Mammoth/Screens/Composer/NewPostViewController.swift
+++ b/Mammoth/Screens/Composer/NewPostViewController.swift
@@ -3372,17 +3372,16 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
     }
     
     func searchForUsers(_ user0: String) {
-        let request = Search.search(query: user0, resolve: true)
+        let request = Search.searchAutocompleteAccounts(query: user0)
         self.formatToolbar2.sizeToFit()
-        (self.currentAcct as? MastodonAcctData)?.client.run(request) { (statuses) in
-            if let stat = (statuses.value) {
+        (self.currentAcct as? MastodonAcctData)?.client.run(request) { (accounts) in
+            if var accountsArray = (accounts.value) {
                 DispatchQueue.main.async {
                     self.formatToolbar2.items = []
                     var allWidths: CGFloat = 0
-                    var zz = stat.accounts
-                    zz = zz.removingDuplicates()
-                    self.userItemsAll = zz
-                    for (c,_) in zz.enumerated() {
+                    accountsArray = accountsArray.removingDuplicates()
+                    self.userItemsAll = accountsArray
+                    for (c,_) in accountsArray.enumerated() {
                         let view = UIButton()
                         
                         let im = UIButton()
@@ -3390,14 +3389,14 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
                         im.frame = CGRect(x: 0, y: 10, width: (self.formatToolbar2.frame.size.height) - 20, height: (self.formatToolbar2.frame.size.height) - 20)
                         im.layer.cornerRadius = ((self.formatToolbar2.frame.size.height) - 20)/2
                         im.imageView?.contentMode = .scaleAspectFill
-                        if let ur = URL(string: zz[c].avatar) {
+                        if let ur = URL(string: accountsArray[c].avatar) {
                             im.sd_setImage(with: ur, for: .normal)
                         }
                         im.layer.masksToBounds = true
                         view.addSubview(im)
                         
                         let titl = UILabel()
-                        titl.text = "@\(zz[c].acct)"
+                        titl.text = "@\(accountsArray[c].acct)"
                         titl.textColor = .custom.baseTint
                         titl.frame = CGRect(x: (self.formatToolbar2.frame.size.height) - 10, y: 0, width: (self.view.bounds.width) - (self.formatToolbar2.frame.size.height), height: (self.formatToolbar2.frame.size.height))
                         titl.sizeToFit()
@@ -3412,7 +3411,7 @@ class NewPostViewController: UIViewController, UITableViewDataSource, UITableVie
                         let x0 = UIBarButtonItem(customView: view)
                         x0.width = wid
                         allWidths += wid
-                        x0.accessibilityLabel = "@\(zz[c].acct)"
+                        x0.accessibilityLabel = "@\(accountsArray[c].acct)"
                         
                         self.formatToolbar2.items?.append(x0)
                     }

--- a/Mammoth/Services/Backend/MastodonKit/Requests/Search.swift
+++ b/Mammoth/Services/Backend/MastodonKit/Requests/Search.swift
@@ -71,4 +71,16 @@ public struct Search {
         return Request<Results>(path: "/api/v2/search", method: method)
     }
     
+    public static func searchAutocompleteAccounts(query: String) -> Request<[Account]> {
+        // https://moth.social/api/v1/accounts/search?q=stro&resolve=false&limit=4
+        // Using a v1 api for account autocomplete because there seems to be compatibility issues with moth.social and mastodon.social.
+        // If this breaks, we should check what masto:web is doing. If they move account search in composer back to v2, we should as well.
+        let parameters = [
+            Parameter(name: "q", value: query),
+            Parameter(name: "resolve", value: "true"),
+            Parameter(name: "limit", value: "5")
+        ]
+        let method = HTTPMethod.get(.parameters(parameters))
+        return Request<[Account]>(path: "/api/v1/accounts/search", method: method)
+    }
 }


### PR DESCRIPTION
Tested on moth.social (the one originally broken), mastodon.social, my own mastodon server. 