### PR TITLE
Use preUpdateScrollPosition

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -929,7 +929,7 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
             log.debug("tableview change: \(updateType) for \(feedType)")
                         
             // Cache scroll position pre-update
-            let scrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
+            let preUpdateScrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
 
             if shouldFreezeAnimations {
                 CATransaction.begin()
@@ -944,11 +944,11 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
                     return
                 }
                 
-                if let scrollPosition {
+                if let preUpdateScrollPosition {
                     // Forcing a second scrollToPosition call on completion
                     // makes sure the scroll action happens correcty.
                     // Keep both of them to make the feed less jumpy on feed updates.
-                    self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+                    self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
                 }
                 
                 if shouldFreezeAnimations {
@@ -969,8 +969,8 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
             }
                         
             // Revert to pre-update scroll position
-            if let scrollPosition {
-                self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+            if let preUpdateScrollPosition {
+                self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
             }
             
         case .removeAll:
@@ -1010,7 +1010,7 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
 
         case .append:
             // Cache scroll position pre-update
-            let scrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
+            let preUpdateScrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
 
             if shouldFreezeAnimations {
                 CATransaction.begin()
@@ -1027,8 +1027,8 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
                // Forcing a second scrollToPosition call on completion
                // makes sure the scroll action happens correcty.
                // Keep both of them to make the feed less jumpy on feed updates.
-               if let scrollPosition {
-                   self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+               if let preUpdateScrollPosition {
+                   self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
                }
                
                 if shouldFreezeAnimations {
@@ -1037,8 +1037,8 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
                onCompleted?()
             }
 
-            if let scrollPosition {
-               self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+            if let preUpdateScrollPosition {
+               self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
             }
         }
     }

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -875,7 +875,7 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
             self.isInsertingContent = true
             
             // Cache scroll position pre-update
-            let scrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
+            let preUpdateScrollPosition = self.cacheScrollPosition(tableView: self.tableView, forFeed: feedType, scrollReference: .top)
 
             if shouldFreezeAnimations && self.viewModel.dataSource != nil {
                 CATransaction.begin()
@@ -890,11 +890,11 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
                     return
                 }
                 
-                if let scrollPosition {
+                if let preUpdateScrollPosition {
                     // Forcing a second scrollToPosition call on completion
                     // makes sure the scroll action happens correcty.
                     // Keep both of them to make the feed less jumpy on feed updates.
-                    self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+                    self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
                 }
 
                 onCompleted?()
@@ -919,8 +919,8 @@ extension NewsFeedViewController: NewsFeedViewModelDelegate {
             }
                         
             // Revert to pre-update scroll position
-            if let scrollPosition {
-                self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: scrollPosition)
+            if let preUpdateScrollPosition {
+                self.scrollToPosition(tableView: self.tableView, snapshot: snapshot, position: preUpdateScrollPosition)
             }
             
         case .inject:


### PR DESCRIPTION
If I'm reading this correctly, sometimes the new scrollPosition was being used in the place of the pre-updateScrollPosition.

I gave the pre-updateScrollPosition its own name, and used it where it made sense based on the comments.