### PR TITLE
Skip iCloud sync if user has manually scrolled

### DIFF
--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -1287,6 +1287,8 @@ private extension NewsFeedViewController {
 // MARK: - Jump to newest
 extension NewsFeedViewController: JumpToNewest {
     func jumpToNewest() {
+        self.viewModel.userHasScrolledManually = true
+
         if !self.viewModel.pollingReachedTop {
             // refresh because we didn't reach the top of the feed.
             self.viewModel.stopPollingListData()

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -791,6 +791,7 @@ extension NewsFeedViewController {
     
     func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
         self.isScrollingProgrammatically = false
+        self.viewModel.userHasScrolledManually = true
 
         self.viewModel.cancelAllItemSyncs()
         

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewController.swift
@@ -728,6 +728,11 @@ extension NewsFeedViewController {
         viewModel.cancelPreloadCards(atIndexPaths: indexPaths)
     }
     
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        log.debug("Manual: scrollViewWillBeginDragging setting userHasScrolledManually to true for feed \(self.type)")
+        viewModel.userHasScrolledManually = true
+    }
+    
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         self.isScrollingProgrammatically = !self.tableView.isDecelerating && !self.tableView.isTracking && !(self.tableView.indexPathsForVisibleRows ?? []).isEmpty
         
@@ -1181,10 +1186,11 @@ internal extension NewsFeedViewController {
 private extension NewsFeedViewController {
     func scrollToPosition(tableView: UITableView, position: NewsFeedScrollPosition) {
         if tableView.frame.width > 0 {
+            log.debug("iCloud Sync: scrollToPosition for \(self.type)")
             if case .postCard = position.model {
                 if let indexPath = viewModel.getIndexPathForItem(item: position.model!) {
                     let yOffset = tableView.rectForRow(at: indexPath).origin.y - position.offset
-                    log.debug("iCloud Sync: ATTEMPTING TO CLOUD SCROLL")
+                    log.debug("iCloud Sync: ATTEMPTING TO CLOUD SCROLL for \(self.type)")
                     // we need to include an inset when the background is translucent
                     var additionalOffset = 0.0
                     if UIDevice.current.userInterfaceIdiom == .phone && !self.additionalSafeAreaInsets.top.isZero {
@@ -1197,13 +1203,13 @@ private extension NewsFeedViewController {
                         tableView.contentOffset.y = yOffset - self.view.safeAreaInsets.top
                     }
                 } else {
-                    log.error("iCloud Sync: #scrollToPosition1: no indexpath found")
+                    log.error("iCloud Sync: #scrollToPosition1: no indexpath found for \(self.type)")
                 }
             } else {
-                log.error("iCloud Sync: #scrollToPosition1: position.model is not a postcard")
+                log.error("iCloud Sync: #scrollToPosition1: position.model is not a postcard for \(self.type)")
             }
         } else {
-            log.error("iCloud Sync: #scrollToPosition1: tableview frame not greater than 0")
+            log.error("iCloud Sync: #scrollToPosition1: tableview frame not greater than 0 for \(self.type)")
         }
     }
     

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel+Services.swift
@@ -670,6 +670,13 @@ extension NewsFeedViewModel {
     }
     
     func scrollToCloudPosition(forFeedType feedType: NewsFeedTypes) {
+        
+        // If user has scrolled manually, don't scroll to cloud position
+        if self.userHasScrolledManually {
+            log.debug("iCloud Sync: NOT scrolling to cloud position; user has scrolled manually for feed \(feedType)")
+            return
+        }
+
         // If it's currently scrolling, don't scroll to cloud position
         let operatingTableView = self.delegate!.operatingTableView()
         if !operatingTableView.isTracking && !operatingTableView.isDecelerating {

--- a/Mammoth/Screens/HomeScreen/NewsFeedViewModel.swift
+++ b/Mammoth/Screens/HomeScreen/NewsFeedViewModel.swift
@@ -427,6 +427,7 @@ class NewsFeedViewModel {
     
     internal var scrollPositions = NewsFeedScrollPositions()
     internal var unreadCounts = NewsFeedUnreadStates()
+    public var userHasScrolledManually: Bool = false
 
     internal let savingQueue = DispatchQueue(label: "NewsFeedViewModel Saving", qos: .utility)
 


### PR DESCRIPTION
- add a userHasScrolledManually: Bool flag to newsFeedViewModel
- set userHasScrolledManually to true in NewsFeedViewController.scrollViewWillBeginDragging()
- have scrollToCloudPosition() bail if this is set to true